### PR TITLE
feat: add contextual breadcrumbs on detail and form pages

### DIFF
--- a/frontend/src/components/Breadcrumb.jsx
+++ b/frontend/src/components/Breadcrumb.jsx
@@ -1,0 +1,23 @@
+import { Link } from 'react-router-dom'
+
+export default function Breadcrumb({ items }) {
+  return (
+    <nav className="breadcrumb" aria-label="Breadcrumb">
+      {items.map((item, index) => {
+        const isLast = index === items.length - 1
+        return (
+          <span key={index} className="breadcrumb-item">
+            {!isLast ? (
+              <>
+                <Link to={item.to} className="breadcrumb-link">{item.label}</Link>
+                <span className="breadcrumb-sep" aria-hidden="true">›</span>
+              </>
+            ) : (
+              <span className="breadcrumb-current">{item.label}</span>
+            )}
+          </span>
+        )
+      })}
+    </nav>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -398,6 +398,32 @@ a:hover { text-decoration: underline; }
 .btn-sm { padding: 0.3rem 0.65rem; font-size: 13px; }
 .btn-group { display: flex; gap: 0.5rem; }
 
+/* ── Breadcrumb ── */
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-bottom: 0.75rem;
+  font-size: 13px;
+}
+
+.breadcrumb-item {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.breadcrumb-link {
+  color: #6b7280;
+  text-decoration: none;
+}
+.breadcrumb-link:hover { color: #2563eb; text-decoration: underline; }
+
+.breadcrumb-sep { color: #9ca3af; }
+
+.breadcrumb-current { color: #374151; font-weight: 500; }
+
 /* ── Page header ── */
 .page-header {
   display: flex;

--- a/frontend/src/pages/accounts/AccountDetail.jsx
+++ b/frontend/src/pages/accounts/AccountDetail.jsx
@@ -4,6 +4,7 @@ import { accountsApi } from '../../api/accounts.api.js'
 import { contactsApi } from '../../api/contacts.api.js'
 import ActivityLogForm from '../../components/ActivityLogForm.jsx'
 import ActivityTimeline from '../../components/ActivityTimeline.jsx'
+import Breadcrumb from '../../components/Breadcrumb.jsx'
 
 export default function AccountDetail() {
   const { id } = useParams()
@@ -39,6 +40,10 @@ export default function AccountDetail() {
 
   return (
     <div>
+      <Breadcrumb items={[
+        { label: 'Accounts', to: '/accounts' },
+        { label: account.name },
+      ]} />
       <div className="page-header">
         <h1>{account.name}</h1>
         <div className="btn-group">

--- a/frontend/src/pages/accounts/AccountForm.jsx
+++ b/frontend/src/pages/accounts/AccountForm.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { accountsApi } from '../../api/accounts.api.js'
+import Breadcrumb from '../../components/Breadcrumb.jsx'
 
 const INDUSTRIES = ['Technology', 'Finance', 'Healthcare', 'Retail', 'Manufacturing', 'Education', 'Other']
 const SIZES = ['Small', 'Medium', 'Large', 'Enterprise']
@@ -73,8 +74,20 @@ export default function AccountForm() {
     mutation.mutate(payload)
   }
 
+  const breadcrumbItems = isEdit && existing
+    ? [
+        { label: 'Accounts', to: '/accounts' },
+        { label: existing.name, to: `/accounts/${id}` },
+        { label: 'Edit' },
+      ]
+    : [
+        { label: 'Accounts', to: '/accounts' },
+        { label: 'New Account' },
+      ]
+
   return (
     <div>
+      <Breadcrumb items={breadcrumbItems} />
       <h1>{isEdit ? 'Edit Account' : 'New Account'}</h1>
       <div className="card">
         <form onSubmit={handleSubmit} className="edit-form">

--- a/frontend/src/pages/contacts/ContactDetail.jsx
+++ b/frontend/src/pages/contacts/ContactDetail.jsx
@@ -5,6 +5,7 @@ import { accountsApi } from '../../api/accounts.api.js'
 import { usersApi } from '../../api/users.api.js'
 import ActivityTimeline from '../../components/ActivityTimeline.jsx'
 import ActivityLogForm from '../../components/ActivityLogForm.jsx'
+import Breadcrumb from '../../components/Breadcrumb.jsx'
 
 const STATUS_TRANSITIONS = {
   Lead: ['Prospect', 'Churned'],
@@ -64,6 +65,10 @@ export default function ContactDetail() {
 
   return (
     <div>
+      <Breadcrumb items={[
+        { label: 'Contacts', to: '/contacts' },
+        { label: `${contact.firstName} ${contact.lastName}` },
+      ]} />
       <div className="page-header">
         <h1>{contact.firstName} {contact.lastName}</h1>
         <div className="btn-group">

--- a/frontend/src/pages/contacts/ContactForm.jsx
+++ b/frontend/src/pages/contacts/ContactForm.jsx
@@ -4,6 +4,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { contactsApi } from '../../api/contacts.api.js'
 import { accountsApi } from '../../api/accounts.api.js'
 import { usersApi } from '../../api/users.api.js'
+import Breadcrumb from '../../components/Breadcrumb.jsx'
 
 const STATUSES = ['Lead', 'Prospect', 'Customer', 'Churned']
 
@@ -73,8 +74,20 @@ export default function ContactForm() {
     mutation.mutate(payload)
   }
 
+  const breadcrumbItems = isEdit && existing
+    ? [
+        { label: 'Contacts', to: '/contacts' },
+        { label: `${existing.firstName} ${existing.lastName}`, to: `/contacts/${id}` },
+        { label: 'Edit' },
+      ]
+    : [
+        { label: 'Contacts', to: '/contacts' },
+        { label: 'New Contact' },
+      ]
+
   return (
     <div>
+      <Breadcrumb items={breadcrumbItems} />
       <h1>{isEdit ? 'Edit Contact' : 'New Contact'}</h1>
       <div className="card">
         <form onSubmit={handleSubmit} className="edit-form">

--- a/frontend/src/pages/deals/DealDetail.jsx
+++ b/frontend/src/pages/deals/DealDetail.jsx
@@ -6,6 +6,7 @@ import { contactsApi } from '../../api/contacts.api.js'
 import { accountsApi } from '../../api/accounts.api.js'
 import ActivityTimeline from '../../components/ActivityTimeline.jsx'
 import ActivityLogForm from '../../components/ActivityLogForm.jsx'
+import Breadcrumb from '../../components/Breadcrumb.jsx'
 
 const STAGES = ['Prospecting', 'Proposal', 'Negotiation', 'ClosedWon', 'ClosedLost']
 const ROLES = ['DecisionMaker', 'Influencer', 'Champion']
@@ -68,6 +69,10 @@ export default function DealDetail() {
 
   return (
     <div style={{ maxWidth: '800px' }}>
+      <Breadcrumb items={[
+        { label: 'Pipeline', to: '/deals' },
+        { label: deal.title },
+      ]} />
       <div className="page-header">
         <div>
           <h1>{deal.title}</h1>

--- a/frontend/src/pages/deals/DealForm.jsx
+++ b/frontend/src/pages/deals/DealForm.jsx
@@ -4,6 +4,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { dealsApi } from '../../api/deals.api.js'
 import { accountsApi } from '../../api/accounts.api.js'
 import { usersApi } from '../../api/users.api.js'
+import Breadcrumb from '../../components/Breadcrumb.jsx'
 
 const STAGES = ['Prospecting', 'Proposal', 'Negotiation', 'ClosedWon', 'ClosedLost']
 
@@ -83,8 +84,20 @@ export default function DealForm() {
 
   const set = (field) => (e) => setForm((f) => ({ ...f, [field]: e.target.value }))
 
+  const breadcrumbItems = isEdit && existing
+    ? [
+        { label: 'Pipeline', to: '/deals' },
+        { label: existing.title, to: `/deals/${id}` },
+        { label: 'Edit' },
+      ]
+    : [
+        { label: 'Pipeline', to: '/deals' },
+        { label: 'New Deal' },
+      ]
+
   return (
     <div style={{ maxWidth: '520px' }}>
+      <Breadcrumb items={breadcrumbItems} />
       <h1>{isEdit ? 'Edit Deal' : 'New Deal'}</h1>
 
       {error && <p className="form-error">{error}</p>}


### PR DESCRIPTION
Adds a reusable Breadcrumb component and renders it on all detail and form pages for Contacts, Accounts, and Deals.

Examples:
- Contacts › John Smith
- Contacts › John Smith › Edit
- Accounts › Acme Corp
- Pipeline › Deal Title › Edit

Closes #3

Generated with [Claude Code](https://claude.ai/code)