### PR TITLE
feat: Slideover panels for create/edit forms

### DIFF
--- a/frontend/src/pages/accounts/AccountDetail.jsx
+++ b/frontend/src/pages/accounts/AccountDetail.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import { accountsApi } from '../../api/accounts.api.js'
@@ -5,6 +6,8 @@ import { contactsApi } from '../../api/contacts.api.js'
 import ActivityLogForm from '../../components/ActivityLogForm.jsx'
 import ActivityTimeline from '../../components/ActivityTimeline.jsx'
 import Breadcrumb from '../../components/Breadcrumb.jsx'
+import AccountForm from './AccountForm.jsx'
+import ContactForm from '../contacts/ContactForm.jsx'
 import { Button } from '../../components/ui/button.jsx'
 import { Badge } from '../../components/ui/badge.jsx'
 import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card.jsx'
@@ -19,6 +22,12 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '../../components/ui/dialog.jsx'
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '../../components/ui/sheet.jsx'
 
 const STATUS_VARIANT = {
   Lead: 'lead',
@@ -31,6 +40,8 @@ export default function AccountDetail() {
   const { id } = useParams()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
+  const [editOpen, setEditOpen] = useState(false)
+  const [addContactOpen, setAddContactOpen] = useState(false)
 
   const { data: account, isLoading, error } = useQuery({
     queryKey: ['account', id],
@@ -74,7 +85,7 @@ export default function AccountDetail() {
       <div className="flex items-center justify-between mb-5">
         <h1 className="text-2xl font-bold text-gray-900">{account.name}</h1>
         <div className="flex gap-2">
-          <Button variant="outline" onClick={() => navigate(`/accounts/${id}/edit`)}>Edit</Button>
+          <Button variant="outline" onClick={() => setEditOpen(true)}>Edit</Button>
           <Dialog>
             <DialogTrigger asChild>
               <Button variant="destructive">Delete</Button>
@@ -127,7 +138,7 @@ export default function AccountDetail() {
         <CardHeader>
           <div className="flex items-center justify-between">
             <CardTitle>Contacts ({contacts.length})</CardTitle>
-            <Button size="sm" variant="outline" onClick={() => navigate('/contacts/new')}>+ Add Contact</Button>
+            <Button size="sm" variant="outline" onClick={() => setAddContactOpen(true)}>+ Add Contact</Button>
           </div>
         </CardHeader>
         <CardContent className="pt-0">
@@ -171,6 +182,38 @@ export default function AccountDetail() {
           <ActivityTimeline accountId={id} queryKey="account-activities" />
         </CardContent>
       </Card>
+
+      <Sheet open={editOpen} onOpenChange={setEditOpen}>
+        <SheetContent className="sm:max-w-lg overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle>Edit Account</SheetTitle>
+          </SheetHeader>
+          <div className="mt-5">
+            <AccountForm
+              id={id}
+              onSuccess={() => setEditOpen(false)}
+              onClose={() => setEditOpen(false)}
+            />
+          </div>
+        </SheetContent>
+      </Sheet>
+
+      <Sheet open={addContactOpen} onOpenChange={setAddContactOpen}>
+        <SheetContent className="sm:max-w-lg overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle>New Contact</SheetTitle>
+          </SheetHeader>
+          <div className="mt-5">
+            <ContactForm
+              onSuccess={(result) => {
+                setAddContactOpen(false)
+                navigate(`/contacts/${result.contactId}`)
+              }}
+              onClose={() => setAddContactOpen(false)}
+            />
+          </div>
+        </SheetContent>
+      </Sheet>
     </div>
   )
 }

--- a/frontend/src/pages/accounts/AccountForm.jsx
+++ b/frontend/src/pages/accounts/AccountForm.jsx
@@ -23,9 +23,11 @@ const EMPTY = {
   street: '', city: '', state: '', postalCode: '', country: '',
 }
 
-export default function AccountForm() {
-  const { id } = useParams()
+export default function AccountForm({ onSuccess, onClose, id: idProp }) {
+  const { id: idParam } = useParams()
+  const id = onClose !== undefined ? idProp : idParam
   const isEdit = !!id
+  const isSheet = onClose !== undefined
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [fields, setFields] = useState(EMPTY)
@@ -59,7 +61,11 @@ export default function AccountForm() {
     onSuccess: (result) => {
       queryClient.invalidateQueries({ queryKey: ['accounts'] })
       if (isEdit) queryClient.invalidateQueries({ queryKey: ['account', id] })
-      navigate(isEdit ? `/accounts/${id}` : `/accounts/${result.accountId}`)
+      if (onSuccess) {
+        onSuccess(result)
+      } else {
+        navigate(isEdit ? `/accounts/${id}` : `/accounts/${result.accountId}`)
+      }
     },
     onError: (err) => setError(err.message),
   })
@@ -95,6 +101,79 @@ export default function AccountForm() {
         { label: 'New Account' },
       ]
 
+  const formFields = (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      {error && (
+        <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-md border border-red-200">{error}</p>
+      )}
+      <div className="flex flex-col gap-1.5">
+        <Label>Name *</Label>
+        <Input value={fields.name} onChange={(e) => set('name', e.target.value)} required />
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div className="flex flex-col gap-1.5">
+          <Label>Industry</Label>
+          <Select value={fields.industry || '_none'} onValueChange={(v) => set('industry', v === '_none' ? '' : v)}>
+            <SelectTrigger><SelectValue placeholder="— Select —" /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="_none">— Select —</SelectItem>
+              {INDUSTRIES.map((i) => <SelectItem key={i} value={i}>{i}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label>Size</Label>
+          <Select value={fields.size || '_none'} onValueChange={(v) => set('size', v === '_none' ? '' : v)}>
+            <SelectTrigger><SelectValue placeholder="— Select —" /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="_none">— Select —</SelectItem>
+              {SIZES.map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <Label>Website</Label>
+        <Input type="url" value={fields.website} onChange={(e) => set('website', e.target.value)} placeholder="https://" />
+      </div>
+      <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mt-2">Address</p>
+      <div className="flex flex-col gap-1.5">
+        <Label>Street</Label>
+        <Input value={fields.street} onChange={(e) => set('street', e.target.value)} />
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div className="flex flex-col gap-1.5">
+          <Label>City</Label>
+          <Input value={fields.city} onChange={(e) => set('city', e.target.value)} />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label>State / Region</Label>
+          <Input value={fields.state} onChange={(e) => set('state', e.target.value)} />
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div className="flex flex-col gap-1.5">
+          <Label>Postal Code</Label>
+          <Input value={fields.postalCode} onChange={(e) => set('postalCode', e.target.value)} />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label>Country</Label>
+          <Input value={fields.country} onChange={(e) => set('country', e.target.value)} />
+        </div>
+      </div>
+      <div className="flex gap-3 pt-2">
+        <Button type="submit" disabled={mutation.isPending}>
+          {mutation.isPending ? 'Saving…' : isEdit ? 'Save changes' : 'Create account'}
+        </Button>
+        <Button type="button" variant="outline" onClick={() => onClose ? onClose() : navigate(-1)}>Cancel</Button>
+      </div>
+    </form>
+  )
+
+  if (isSheet) {
+    return formFields
+  }
+
   return (
     <div>
       <Breadcrumb items={breadcrumbItems} />
@@ -103,72 +182,7 @@ export default function AccountForm() {
       </h1>
       <Card>
         <CardContent className="pt-6">
-          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-            {error && (
-              <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-md border border-red-200">{error}</p>
-            )}
-            <div className="flex flex-col gap-1.5">
-              <Label>Name *</Label>
-              <Input value={fields.name} onChange={(e) => set('name', e.target.value)} required />
-            </div>
-            <div className="grid grid-cols-2 gap-4">
-              <div className="flex flex-col gap-1.5">
-                <Label>Industry</Label>
-                <Select value={fields.industry || '_none'} onValueChange={(v) => set('industry', v === '_none' ? '' : v)}>
-                  <SelectTrigger><SelectValue placeholder="— Select —" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="_none">— Select —</SelectItem>
-                    {INDUSTRIES.map((i) => <SelectItem key={i} value={i}>{i}</SelectItem>)}
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="flex flex-col gap-1.5">
-                <Label>Size</Label>
-                <Select value={fields.size || '_none'} onValueChange={(v) => set('size', v === '_none' ? '' : v)}>
-                  <SelectTrigger><SelectValue placeholder="— Select —" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="_none">— Select —</SelectItem>
-                    {SIZES.map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <Label>Website</Label>
-              <Input type="url" value={fields.website} onChange={(e) => set('website', e.target.value)} placeholder="https://" />
-            </div>
-            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mt-2">Address</p>
-            <div className="flex flex-col gap-1.5">
-              <Label>Street</Label>
-              <Input value={fields.street} onChange={(e) => set('street', e.target.value)} />
-            </div>
-            <div className="grid grid-cols-2 gap-4">
-              <div className="flex flex-col gap-1.5">
-                <Label>City</Label>
-                <Input value={fields.city} onChange={(e) => set('city', e.target.value)} />
-              </div>
-              <div className="flex flex-col gap-1.5">
-                <Label>State / Region</Label>
-                <Input value={fields.state} onChange={(e) => set('state', e.target.value)} />
-              </div>
-            </div>
-            <div className="grid grid-cols-2 gap-4">
-              <div className="flex flex-col gap-1.5">
-                <Label>Postal Code</Label>
-                <Input value={fields.postalCode} onChange={(e) => set('postalCode', e.target.value)} />
-              </div>
-              <div className="flex flex-col gap-1.5">
-                <Label>Country</Label>
-                <Input value={fields.country} onChange={(e) => set('country', e.target.value)} />
-              </div>
-            </div>
-            <div className="flex gap-3 pt-2">
-              <Button type="submit" disabled={mutation.isPending}>
-                {mutation.isPending ? 'Saving…' : isEdit ? 'Save changes' : 'Create account'}
-              </Button>
-              <Button type="button" variant="outline" onClick={() => navigate(-1)}>Cancel</Button>
-            </div>
-          </form>
+          {formFields}
         </CardContent>
       </Card>
     </div>

--- a/frontend/src/pages/accounts/AccountList.jsx
+++ b/frontend/src/pages/accounts/AccountList.jsx
@@ -1,13 +1,22 @@
+import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Link, useNavigate } from 'react-router-dom'
 import { accountsApi } from '../../api/accounts.api.js'
+import AccountForm from './AccountForm.jsx'
 import { Button } from '../../components/ui/button.jsx'
 import { Skeleton } from '../../components/ui/skeleton.jsx'
 import { Card } from '../../components/ui/card.jsx'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../components/ui/table.jsx'
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '../../components/ui/sheet.jsx'
 
 export default function AccountList() {
   const navigate = useNavigate()
+  const [sheetOpen, setSheetOpen] = useState(false)
 
   const { data: accounts = [], isLoading, error } = useQuery({
     queryKey: ['accounts'],
@@ -18,7 +27,7 @@ export default function AccountList() {
     <div>
       <div className="flex items-center justify-between mb-5">
         <h1 className="text-2xl font-bold text-gray-900">Accounts</h1>
-        <Button onClick={() => navigate('/accounts/new')}>+ New Account</Button>
+        <Button onClick={() => setSheetOpen(true)}>+ New Account</Button>
       </div>
 
       {isLoading ? (
@@ -71,6 +80,23 @@ export default function AccountList() {
           </Table>
         </Card>
       )}
+
+      <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+        <SheetContent className="sm:max-w-lg overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle>New Account</SheetTitle>
+          </SheetHeader>
+          <div className="mt-5">
+            <AccountForm
+              onSuccess={(result) => {
+                setSheetOpen(false)
+                navigate(`/accounts/${result.accountId}`)
+              }}
+              onClose={() => setSheetOpen(false)}
+            />
+          </div>
+        </SheetContent>
+      </Sheet>
     </div>
   )
 }

--- a/frontend/src/pages/contacts/ContactDetail.jsx
+++ b/frontend/src/pages/contacts/ContactDetail.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import { contactsApi } from '../../api/contacts.api.js'
@@ -6,6 +7,7 @@ import { usersApi } from '../../api/users.api.js'
 import ActivityTimeline from '../../components/ActivityTimeline.jsx'
 import ActivityLogForm from '../../components/ActivityLogForm.jsx'
 import Breadcrumb from '../../components/Breadcrumb.jsx'
+import ContactForm from './ContactForm.jsx'
 import { Button } from '../../components/ui/button.jsx'
 import { Badge } from '../../components/ui/badge.jsx'
 import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card.jsx'
@@ -19,6 +21,12 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '../../components/ui/dialog.jsx'
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '../../components/ui/sheet.jsx'
 import { toast } from '../../hooks/use-toast.js'
 
 const STATUS_TRANSITIONS = {
@@ -39,6 +47,7 @@ export default function ContactDetail() {
   const { id } = useParams()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
+  const [editOpen, setEditOpen] = useState(false)
 
   const { data: contact, isLoading, error } = useQuery({
     queryKey: ['contact', id],
@@ -98,7 +107,7 @@ export default function ContactDetail() {
       <div className="flex items-center justify-between mb-5">
         <h1 className="text-2xl font-bold text-gray-900">{contact.firstName} {contact.lastName}</h1>
         <div className="flex gap-2">
-          <Button variant="outline" onClick={() => navigate(`/contacts/${id}/edit`)}>Edit</Button>
+          <Button variant="outline" onClick={() => setEditOpen(true)}>Edit</Button>
           <Dialog>
             <DialogTrigger asChild>
               <Button variant="destructive">Delete</Button>
@@ -202,6 +211,21 @@ export default function ContactDetail() {
           <ActivityTimeline contactId={id} queryKey="contact-activities" />
         </CardContent>
       </Card>
+
+      <Sheet open={editOpen} onOpenChange={setEditOpen}>
+        <SheetContent className="sm:max-w-lg overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle>Edit Contact</SheetTitle>
+          </SheetHeader>
+          <div className="mt-5">
+            <ContactForm
+              id={id}
+              onSuccess={() => setEditOpen(false)}
+              onClose={() => setEditOpen(false)}
+            />
+          </div>
+        </SheetContent>
+      </Sheet>
     </div>
   )
 }

--- a/frontend/src/pages/contacts/ContactForm.jsx
+++ b/frontend/src/pages/contacts/ContactForm.jsx
@@ -20,9 +20,11 @@ import {
 const STATUSES = ['Lead', 'Prospect', 'Customer', 'Churned']
 const EMPTY = { firstName: '', lastName: '', email: '', phone: '', status: 'Lead', accountId: '', ownerId: '' }
 
-export default function ContactForm() {
-  const { id } = useParams()
+export default function ContactForm({ onSuccess, onClose, id: idProp }) {
+  const { id: idParam } = useParams()
+  const id = onClose !== undefined ? idProp : idParam
   const isEdit = !!id
+  const isSheet = onClose !== undefined
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [fields, setFields] = useState(EMPTY)
@@ -64,7 +66,11 @@ export default function ContactForm() {
     onSuccess: (result) => {
       queryClient.invalidateQueries({ queryKey: ['contacts'] })
       if (isEdit) queryClient.invalidateQueries({ queryKey: ['contact', id] })
-      navigate(isEdit ? `/contacts/${id}` : `/contacts/${result.contactId}`)
+      if (onSuccess) {
+        onSuccess(result)
+      } else {
+        navigate(isEdit ? `/contacts/${id}` : `/contacts/${result.contactId}`)
+      }
     },
     onError: (err) => setError(err.message),
   })
@@ -94,6 +100,75 @@ export default function ContactForm() {
         { label: 'New Contact' },
       ]
 
+  const formFields = (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      {error && (
+        <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-md border border-red-200">{error}</p>
+      )}
+      <div className="grid grid-cols-2 gap-4">
+        <div className="flex flex-col gap-1.5">
+          <Label>First Name *</Label>
+          <Input value={fields.firstName} onChange={(e) => set('firstName', e.target.value)} required />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label>Last Name *</Label>
+          <Input value={fields.lastName} onChange={(e) => set('lastName', e.target.value)} required />
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div className="flex flex-col gap-1.5">
+          <Label>Email *</Label>
+          <Input type="email" value={fields.email} onChange={(e) => set('email', e.target.value)} required />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label>Phone</Label>
+          <Input type="tel" value={fields.phone} onChange={(e) => set('phone', e.target.value)} />
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div className="flex flex-col gap-1.5">
+          <Label>Status</Label>
+          <Select value={fields.status} onValueChange={(v) => set('status', v)}>
+            <SelectTrigger><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {STATUSES.map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label>Account</Label>
+          <Select value={fields.accountId || '_none'} onValueChange={(v) => set('accountId', v === '_none' ? '' : v)}>
+            <SelectTrigger><SelectValue placeholder="— None —" /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="_none">— None —</SelectItem>
+              {accounts.map((a) => <SelectItem key={a.accountId} value={a.accountId}>{a.name}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <Label>Owner</Label>
+        <Select value={fields.ownerId || '_unassigned'} onValueChange={(v) => set('ownerId', v === '_unassigned' ? '' : v)}>
+          <SelectTrigger><SelectValue placeholder="— Unassigned —" /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="_unassigned">— Unassigned —</SelectItem>
+            {team.map((m) => <SelectItem key={m.userId} value={m.userId}>{m.displayName || m.userId}</SelectItem>)}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="flex gap-3 pt-2">
+        <Button type="submit" disabled={mutation.isPending}>
+          {mutation.isPending ? 'Saving…' : isEdit ? 'Save changes' : 'Create contact'}
+        </Button>
+        <Button type="button" variant="outline" onClick={() => onClose ? onClose() : navigate(-1)}>Cancel</Button>
+      </div>
+    </form>
+  )
+
+  if (isSheet) {
+    return formFields
+  }
+
   return (
     <div>
       <Breadcrumb items={breadcrumbItems} />
@@ -102,68 +177,7 @@ export default function ContactForm() {
       </h1>
       <Card>
         <CardContent className="pt-6">
-          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-            {error && (
-              <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-md border border-red-200">{error}</p>
-            )}
-            <div className="grid grid-cols-2 gap-4">
-              <div className="flex flex-col gap-1.5">
-                <Label>First Name *</Label>
-                <Input value={fields.firstName} onChange={(e) => set('firstName', e.target.value)} required />
-              </div>
-              <div className="flex flex-col gap-1.5">
-                <Label>Last Name *</Label>
-                <Input value={fields.lastName} onChange={(e) => set('lastName', e.target.value)} required />
-              </div>
-            </div>
-            <div className="grid grid-cols-2 gap-4">
-              <div className="flex flex-col gap-1.5">
-                <Label>Email *</Label>
-                <Input type="email" value={fields.email} onChange={(e) => set('email', e.target.value)} required />
-              </div>
-              <div className="flex flex-col gap-1.5">
-                <Label>Phone</Label>
-                <Input type="tel" value={fields.phone} onChange={(e) => set('phone', e.target.value)} />
-              </div>
-            </div>
-            <div className="grid grid-cols-2 gap-4">
-              <div className="flex flex-col gap-1.5">
-                <Label>Status</Label>
-                <Select value={fields.status} onValueChange={(v) => set('status', v)}>
-                  <SelectTrigger><SelectValue /></SelectTrigger>
-                  <SelectContent>
-                    {STATUSES.map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="flex flex-col gap-1.5">
-                <Label>Account</Label>
-                <Select value={fields.accountId || '_none'} onValueChange={(v) => set('accountId', v === '_none' ? '' : v)}>
-                  <SelectTrigger><SelectValue placeholder="— None —" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="_none">— None —</SelectItem>
-                    {accounts.map((a) => <SelectItem key={a.accountId} value={a.accountId}>{a.name}</SelectItem>)}
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <Label>Owner</Label>
-              <Select value={fields.ownerId || '_unassigned'} onValueChange={(v) => set('ownerId', v === '_unassigned' ? '' : v)}>
-                <SelectTrigger><SelectValue placeholder="— Unassigned —" /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="_unassigned">— Unassigned —</SelectItem>
-                  {team.map((m) => <SelectItem key={m.userId} value={m.userId}>{m.displayName || m.userId}</SelectItem>)}
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="flex gap-3 pt-2">
-              <Button type="submit" disabled={mutation.isPending}>
-                {mutation.isPending ? 'Saving…' : isEdit ? 'Save changes' : 'Create contact'}
-              </Button>
-              <Button type="button" variant="outline" onClick={() => navigate(-1)}>Cancel</Button>
-            </div>
-          </form>
+          {formFields}
         </CardContent>
       </Card>
     </div>

--- a/frontend/src/pages/contacts/ContactList.jsx
+++ b/frontend/src/pages/contacts/ContactList.jsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { Link, useNavigate } from 'react-router-dom'
 import { contactsApi } from '../../api/contacts.api.js'
 import { usersApi } from '../../api/users.api.js'
+import ContactForm from './ContactForm.jsx'
 import { Button } from '../../components/ui/button.jsx'
 import { Badge } from '../../components/ui/badge.jsx'
 import { Skeleton } from '../../components/ui/skeleton.jsx'
@@ -15,6 +16,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../../components/ui/select.jsx'
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '../../components/ui/sheet.jsx'
 
 const STATUSES = ['Lead', 'Prospect', 'Customer', 'Churned']
 
@@ -29,6 +36,7 @@ export default function ContactList() {
   const navigate = useNavigate()
   const [statusFilter, setStatusFilter] = useState('')
   const [ownerFilter, setOwnerFilter] = useState('')
+  const [sheetOpen, setSheetOpen] = useState(false)
 
   const { data: contacts = [], isLoading, error } = useQuery({
     queryKey: ['contacts', { status: statusFilter, ownerId: ownerFilter }],
@@ -44,7 +52,7 @@ export default function ContactList() {
     <div>
       <div className="flex items-center justify-between mb-5">
         <h1 className="text-2xl font-bold text-gray-900">Contacts</h1>
-        <Button onClick={() => navigate('/contacts/new')}>+ New Contact</Button>
+        <Button onClick={() => setSheetOpen(true)}>+ New Contact</Button>
       </div>
 
       {/* Filters */}
@@ -127,6 +135,23 @@ export default function ContactList() {
           </Table>
         </Card>
       )}
+
+      <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+        <SheetContent className="sm:max-w-lg overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle>New Contact</SheetTitle>
+          </SheetHeader>
+          <div className="mt-5">
+            <ContactForm
+              onSuccess={(result) => {
+                setSheetOpen(false)
+                navigate(`/contacts/${result.contactId}`)
+              }}
+              onClose={() => setSheetOpen(false)}
+            />
+          </div>
+        </SheetContent>
+      </Sheet>
     </div>
   )
 }

--- a/frontend/src/pages/deals/DealDetail.jsx
+++ b/frontend/src/pages/deals/DealDetail.jsx
@@ -7,6 +7,7 @@ import { accountsApi } from '../../api/accounts.api.js'
 import ActivityTimeline from '../../components/ActivityTimeline.jsx'
 import ActivityLogForm from '../../components/ActivityLogForm.jsx'
 import Breadcrumb from '../../components/Breadcrumb.jsx'
+import DealForm from './DealForm.jsx'
 import { Button } from '../../components/ui/button.jsx'
 import { Badge } from '../../components/ui/badge.jsx'
 import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card.jsx'
@@ -29,6 +30,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../../components/ui/select.jsx'
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '../../components/ui/sheet.jsx'
 
 const STAGES = ['Prospecting', 'Proposal', 'Negotiation', 'ClosedWon', 'ClosedLost']
 const ROLES = ['DecisionMaker', 'Influencer', 'Champion']
@@ -39,6 +46,7 @@ export default function DealDetail() {
   const queryClient = useQueryClient()
   const [contactId, setContactId] = useState('')
   const [contactRole, setContactRole] = useState('Influencer')
+  const [editOpen, setEditOpen] = useState(false)
 
   const { data: deal, isLoading, error } = useQuery({
     queryKey: ['deal', id],
@@ -113,7 +121,7 @@ export default function DealDetail() {
           {account && <p className="text-sm text-gray-500 mt-0.5">{account.name}</p>}
         </div>
         <div className="flex gap-2">
-          <Button variant="outline" onClick={() => navigate(`/deals/${id}/edit`)}>Edit</Button>
+          <Button variant="outline" onClick={() => setEditOpen(true)}>Edit</Button>
           <Dialog>
             <DialogTrigger asChild>
               <Button variant="destructive">Delete</Button>
@@ -253,6 +261,21 @@ export default function DealDetail() {
           <ActivityTimeline dealId={id} queryKey="deal-activities" />
         </CardContent>
       </Card>
+
+      <Sheet open={editOpen} onOpenChange={setEditOpen}>
+        <SheetContent className="sm:max-w-lg overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle>Edit Deal</SheetTitle>
+          </SheetHeader>
+          <div className="mt-5">
+            <DealForm
+              id={id}
+              onSuccess={() => setEditOpen(false)}
+              onClose={() => setEditOpen(false)}
+            />
+          </div>
+        </SheetContent>
+      </Sheet>
     </div>
   )
 }

--- a/frontend/src/pages/deals/DealForm.jsx
+++ b/frontend/src/pages/deals/DealForm.jsx
@@ -19,9 +19,11 @@ import {
 
 const STAGES = ['Prospecting', 'Proposal', 'Negotiation', 'ClosedWon', 'ClosedLost']
 
-export default function DealForm() {
-  const { id } = useParams()
+export default function DealForm({ onSuccess, onClose, id: idProp }) {
+  const { id: idParam } = useParams()
+  const id = onClose !== undefined ? idProp : idParam
   const isEdit = !!id
+  const isSheet = onClose !== undefined
   const navigate = useNavigate()
   const queryClient = useQueryClient()
 
@@ -71,7 +73,11 @@ export default function DealForm() {
     onSuccess: (deal) => {
       queryClient.invalidateQueries({ queryKey: ['pipeline'] })
       queryClient.invalidateQueries({ queryKey: ['deals'] })
-      navigate(isEdit ? `/deals/${id}` : `/deals/${deal.dealId}`)
+      if (onSuccess) {
+        onSuccess(deal)
+      } else {
+        navigate(isEdit ? `/deals/${id}` : `/deals/${deal.dealId}`)
+      }
     },
     onError: (err) => setError(err.message),
   })
@@ -105,6 +111,78 @@ export default function DealForm() {
         { label: 'New Deal' },
       ]
 
+  const formFields = (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      {error && (
+        <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-md border border-red-200">{error}</p>
+      )}
+
+      <div className="flex flex-col gap-1.5">
+        <Label>Title *</Label>
+        <Input value={form.title} onChange={set('title')} required />
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label>Account</Label>
+        <Select value={form.accountId || '_none'} onValueChange={setSelect('accountId')}>
+          <SelectTrigger><SelectValue placeholder="— None —" /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="_none">— None —</SelectItem>
+            {accounts.map((a) => <SelectItem key={a.accountId} value={a.accountId}>{a.name}</SelectItem>)}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label>Stage</Label>
+        <Select value={form.stage} onValueChange={(v) => setForm((f) => ({ ...f, stage: v }))}>
+          <SelectTrigger><SelectValue /></SelectTrigger>
+          <SelectContent>
+            {STAGES.map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="flex flex-col gap-1.5">
+          <Label>Value ($)</Label>
+          <Input type="number" min="0" step="0.01" value={form.value} onChange={set('value')} />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label>Probability (%)</Label>
+          <Input type="number" min="0" max="100" value={form.probability} onChange={set('probability')} />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label>Expected Close Date</Label>
+        <Input type="date" value={form.expectedCloseDate} onChange={set('expectedCloseDate')} />
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label>Owner</Label>
+        <Select value={form.ownerId || '_unassigned'} onValueChange={setSelect('ownerId')}>
+          <SelectTrigger><SelectValue placeholder="— Unassigned —" /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="_unassigned">— Unassigned —</SelectItem>
+            {team.map((m) => <SelectItem key={m.userId} value={m.userId}>{m.displayName || m.userId}</SelectItem>)}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex gap-3 pt-2">
+        <Button type="submit" disabled={mutation.isPending}>
+          {isEdit ? 'Save Changes' : 'Create Deal'}
+        </Button>
+        <Button type="button" variant="outline" onClick={() => onClose ? onClose() : navigate(-1)}>Cancel</Button>
+      </div>
+    </form>
+  )
+
+  if (isSheet) {
+    return formFields
+  }
+
   return (
     <div className="max-w-lg">
       <Breadcrumb items={breadcrumbItems} />
@@ -112,71 +190,7 @@ export default function DealForm() {
 
       <Card>
         <CardContent className="pt-6">
-          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-            {error && (
-              <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-md border border-red-200">{error}</p>
-            )}
-
-            <div className="flex flex-col gap-1.5">
-              <Label>Title *</Label>
-              <Input value={form.title} onChange={set('title')} required />
-            </div>
-
-            <div className="flex flex-col gap-1.5">
-              <Label>Account</Label>
-              <Select value={form.accountId || '_none'} onValueChange={setSelect('accountId')}>
-                <SelectTrigger><SelectValue placeholder="— None —" /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="_none">— None —</SelectItem>
-                  {accounts.map((a) => <SelectItem key={a.accountId} value={a.accountId}>{a.name}</SelectItem>)}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="flex flex-col gap-1.5">
-              <Label>Stage</Label>
-              <Select value={form.stage} onValueChange={(v) => setForm((f) => ({ ...f, stage: v }))}>
-                <SelectTrigger><SelectValue /></SelectTrigger>
-                <SelectContent>
-                  {STAGES.map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="grid grid-cols-2 gap-4">
-              <div className="flex flex-col gap-1.5">
-                <Label>Value ($)</Label>
-                <Input type="number" min="0" step="0.01" value={form.value} onChange={set('value')} />
-              </div>
-              <div className="flex flex-col gap-1.5">
-                <Label>Probability (%)</Label>
-                <Input type="number" min="0" max="100" value={form.probability} onChange={set('probability')} />
-              </div>
-            </div>
-
-            <div className="flex flex-col gap-1.5">
-              <Label>Expected Close Date</Label>
-              <Input type="date" value={form.expectedCloseDate} onChange={set('expectedCloseDate')} />
-            </div>
-
-            <div className="flex flex-col gap-1.5">
-              <Label>Owner</Label>
-              <Select value={form.ownerId || '_unassigned'} onValueChange={setSelect('ownerId')}>
-                <SelectTrigger><SelectValue placeholder="— Unassigned —" /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="_unassigned">— Unassigned —</SelectItem>
-                  {team.map((m) => <SelectItem key={m.userId} value={m.userId}>{m.displayName || m.userId}</SelectItem>)}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="flex gap-3 pt-2">
-              <Button type="submit" disabled={mutation.isPending}>
-                {isEdit ? 'Save Changes' : 'Create Deal'}
-              </Button>
-              <Button type="button" variant="outline" onClick={() => navigate(-1)}>Cancel</Button>
-            </div>
-          </form>
+          {formFields}
         </CardContent>
       </Card>
     </div>

--- a/frontend/src/pages/deals/Pipeline.jsx
+++ b/frontend/src/pages/deals/Pipeline.jsx
@@ -2,8 +2,15 @@ import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
 import { dealsApi } from '../../api/deals.api.js'
+import DealForm from './DealForm.jsx'
 import { Button } from '../../components/ui/button.jsx'
 import { Skeleton } from '../../components/ui/skeleton.jsx'
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '../../components/ui/sheet.jsx'
 
 const STAGES = ['Prospecting', 'Proposal', 'Negotiation', 'ClosedWon', 'ClosedLost']
 
@@ -19,6 +26,7 @@ export default function Pipeline() {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [dragging, setDragging] = useState(null)
+  const [sheetOpen, setSheetOpen] = useState(false)
 
   const { data: board = [], isLoading, error } = useQuery({
     queryKey: ['pipeline'],
@@ -72,7 +80,7 @@ export default function Pipeline() {
     <div>
       <div className="flex items-center justify-between mb-5">
         <h1 className="text-2xl font-bold text-gray-900">Pipeline</h1>
-        <Button onClick={() => navigate('/deals/new')}>+ New Deal</Button>
+        <Button onClick={() => setSheetOpen(true)}>+ New Deal</Button>
       </div>
 
       <div className="flex gap-4 overflow-x-auto pb-4 items-start">
@@ -116,6 +124,23 @@ export default function Pipeline() {
           )
         })}
       </div>
+
+      <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+        <SheetContent className="sm:max-w-lg overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle>New Deal</SheetTitle>
+          </SheetHeader>
+          <div className="mt-5">
+            <DealForm
+              onSuccess={(deal) => {
+                setSheetOpen(false)
+                navigate(`/deals/${deal.dealId}`)
+              }}
+              onClose={() => setSheetOpen(false)}
+            />
+          </div>
+        </SheetContent>
+      </Sheet>
     </div>
   )
 }


### PR DESCRIPTION
Open create/edit forms in a right-hand Sheet (slideover) instead of navigating to a full page.

All "+ New" and "Edit" buttons across Contacts, Accounts, and Deals now open a shadcn/ui Sheet panel. Direct URL routes (/contacts/new, etc.) continue to work unchanged.

Closes #5

Generated with [Claude Code](https://claude.ai/code)