### PR TITLE
feat: add pagination controls to all list views

### DIFF
--- a/frontend/src/components/ui/pagination.jsx
+++ b/frontend/src/components/ui/pagination.jsx
@@ -1,0 +1,58 @@
+import { Button } from './button.jsx'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './select.jsx'
+import { PAGE_SIZE_OPTIONS } from '../../hooks/use-pagination.js'
+
+export function Pagination({
+  page,
+  pageSize,
+  totalCount,
+  totalPages,
+  firstRow,
+  lastRow,
+  onPageChange,
+  onPageSizeChange,
+}) {
+  return (
+    <div className="flex items-center justify-between px-4 py-3 border-t border-gray-100 text-sm text-gray-600">
+      <div className="flex items-center gap-2">
+        <span>Rows per page:</span>
+        <Select value={String(pageSize)} onValueChange={(v) => onPageSizeChange(Number(v))}>
+          <SelectTrigger className="h-8 w-20 text-sm">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {PAGE_SIZE_OPTIONS.map((size) => (
+              <SelectItem key={size} value={String(size)}>{size}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex items-center gap-4">
+        <span>
+          {firstRow}–{lastRow} of {totalCount}
+        </span>
+        <div className="flex items-center gap-1">
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 px-2"
+            disabled={page <= 1}
+            onClick={() => onPageChange(page - 1)}
+          >
+            ‹ Prev
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 px-2"
+            disabled={page >= totalPages}
+            onClick={() => onPageChange(page + 1)}
+          >
+            Next ›
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/use-pagination.js
+++ b/frontend/src/hooks/use-pagination.js
@@ -1,0 +1,42 @@
+import { useState, useMemo } from 'react'
+
+export const PAGE_SIZE_OPTIONS = [10, 25, 50]
+
+export function usePagination(data, initialPageSize = 10) {
+  const [page, setPage] = useState(1)
+  const [pageSize, setPageSize] = useState(initialPageSize)
+
+  const totalCount = data.length
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize))
+
+  const safePage = Math.min(page, totalPages)
+
+  const paginatedData = useMemo(() => {
+    const start = (safePage - 1) * pageSize
+    return data.slice(start, start + pageSize)
+  }, [data, safePage, pageSize])
+
+  const handlePageSizeChange = (newSize) => {
+    setPageSize(newSize)
+    setPage(1)
+  }
+
+  const handlePageChange = (newPage) => {
+    setPage(Math.max(1, Math.min(newPage, totalPages)))
+  }
+
+  const firstRow = totalCount === 0 ? 0 : (safePage - 1) * pageSize + 1
+  const lastRow = Math.min(safePage * pageSize, totalCount)
+
+  return {
+    paginatedData,
+    page: safePage,
+    pageSize,
+    totalCount,
+    totalPages,
+    firstRow,
+    lastRow,
+    handlePageChange,
+    handlePageSizeChange,
+  }
+}

--- a/frontend/src/pages/accounts/AccountList.jsx
+++ b/frontend/src/pages/accounts/AccountList.jsx
@@ -14,6 +14,8 @@ import {
   SheetTitle,
 } from '../../components/ui/sheet.jsx'
 import { useSortableTable, SortIcon } from '../../hooks/use-sortable-table.jsx'
+import { usePagination } from '../../hooks/use-pagination.js'
+import { Pagination } from '../../components/ui/pagination.jsx'
 
 export default function AccountList() {
   const navigate = useNavigate()
@@ -25,6 +27,7 @@ export default function AccountList() {
   })
 
   const { sortedData: sortedAccounts, sortKey, sortDir, handleSort } = useSortableTable(accounts, 'name')
+  const pagination = usePagination(sortedAccounts)
 
   return (
     <div>
@@ -62,7 +65,7 @@ export default function AccountList() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {sortedAccounts.map((a) => (
+              {pagination.paginatedData.map((a) => (
                 <TableRow
                   key={a.accountId}
                   className="cursor-pointer"
@@ -89,6 +92,11 @@ export default function AccountList() {
               ))}
             </TableBody>
           </Table>
+          <Pagination
+            {...pagination}
+            onPageChange={pagination.handlePageChange}
+            onPageSizeChange={pagination.handlePageSizeChange}
+          />
         </Card>
       )}
 

--- a/frontend/src/pages/activities/TaskList.jsx
+++ b/frontend/src/pages/activities/TaskList.jsx
@@ -7,6 +7,8 @@ import { Skeleton } from '../../components/ui/skeleton.jsx'
 import { Card, CardContent } from '../../components/ui/card.jsx'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../components/ui/table.jsx'
 import { useSortableTable, SortIcon } from '../../hooks/use-sortable-table.jsx'
+import { usePagination } from '../../hooks/use-pagination.js'
+import { Pagination } from '../../components/ui/pagination.jsx'
 
 function formatDate(iso) {
   if (!iso) return '—'
@@ -35,6 +37,8 @@ export default function TaskList() {
 
   const { sortedData: sortedIncomplete, sortKey, sortDir, handleSort } = useSortableTable(incompleteTasks, 'scheduledAt')
   const { sortedData: sortedCompleted, sortKey: compSortKey, sortDir: compSortDir, handleSort: handleCompSort } = useSortableTable(completedTasks, 'completedAt', 'desc')
+  const incompletePagination = usePagination(sortedIncomplete)
+  const completedPagination = usePagination(sortedCompleted)
 
   if (isLoading) {
     return (
@@ -80,7 +84,7 @@ export default function TaskList() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {sortedIncomplete.map((t) => (
+              {incompletePagination.paginatedData.map((t) => (
                 <TableRow key={t.activityId} className="cursor-default">
                   <TableCell className="font-medium">{t.subject}</TableCell>
                   <TableCell>{formatDate(t.scheduledAt)}</TableCell>
@@ -105,6 +109,11 @@ export default function TaskList() {
               ))}
             </TableBody>
           </Table>
+          <Pagination
+            {...incompletePagination}
+            onPageChange={incompletePagination.handlePageChange}
+            onPageSizeChange={incompletePagination.handlePageSizeChange}
+          />
         </Card>
       )}
 
@@ -127,7 +136,7 @@ export default function TaskList() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {sortedCompleted.map((t) => (
+                {completedPagination.paginatedData.map((t) => (
                   <TableRow key={t.activityId} className="cursor-default opacity-60">
                     <TableCell className="line-through">{t.subject}</TableCell>
                     <TableCell>{formatDate(t.completedAt)}</TableCell>
@@ -143,6 +152,11 @@ export default function TaskList() {
                 ))}
               </TableBody>
             </Table>
+            <Pagination
+              {...completedPagination}
+              onPageChange={completedPagination.handlePageChange}
+              onPageSizeChange={completedPagination.handlePageSizeChange}
+            />
           </Card>
         </details>
       )}

--- a/frontend/src/pages/contacts/ContactList.jsx
+++ b/frontend/src/pages/contacts/ContactList.jsx
@@ -23,6 +23,8 @@ import {
   SheetTitle,
 } from '../../components/ui/sheet.jsx'
 import { useSortableTable, SortIcon } from '../../hooks/use-sortable-table.jsx'
+import { usePagination } from '../../hooks/use-pagination.js'
+import { Pagination } from '../../components/ui/pagination.jsx'
 
 const STATUSES = ['Lead', 'Prospect', 'Customer', 'Churned']
 
@@ -50,6 +52,7 @@ export default function ContactList() {
   })
 
   const { sortedData: sortedContacts, sortKey, sortDir, handleSort } = useSortableTable(contacts, 'lastName')
+  const pagination = usePagination(sortedContacts)
 
   return (
     <div>
@@ -114,7 +117,7 @@ export default function ContactList() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {sortedContacts.map((c) => {
+              {pagination.paginatedData.map((c) => {
                 const owner = team.find((m) => m.userId === c.ownerId)
                 return (
                   <TableRow
@@ -144,6 +147,11 @@ export default function ContactList() {
               })}
             </TableBody>
           </Table>
+          <Pagination
+            {...pagination}
+            onPageChange={pagination.handlePageChange}
+            onPageSizeChange={pagination.handlePageSizeChange}
+          />
         </Card>
       )}
 


### PR DESCRIPTION
Add pagination controls to all list views as requested in #7.

- `usePagination` hook with page, pageSize, and row count logic
- `Pagination` UI component with page size selector (10/25/50), prev/next, and row count
- Wired into ContactList, AccountList, and TaskList (open + completed)

Closes #7

Generated with [Claude Code](https://claude.ai/code)