### PR TITLE
feat: bulk select in data tables (# 9)

### DIFF
--- a/frontend/src/components/BulkActionBar.jsx
+++ b/frontend/src/components/BulkActionBar.jsx
@@ -1,0 +1,26 @@
+import { X } from 'lucide-react'
+import { Button } from './ui/button.jsx'
+
+export function BulkActionBar({ selectedCount, onClearSelection, children }) {
+  if (selectedCount === 0) return null
+
+  return (
+    <div className="flex items-center gap-3 px-4 py-2 bg-blue-50 border-b border-blue-100">
+      <span className="text-sm font-medium text-blue-800 shrink-0">
+        {selectedCount} selected
+      </span>
+      <div className="flex gap-2 flex-1 flex-wrap">
+        {children}
+      </div>
+      <Button
+        size="icon"
+        variant="ghost"
+        className="h-7 w-7 shrink-0 text-blue-700 hover:text-blue-900 hover:bg-blue-100"
+        onClick={onClearSelection}
+        title="Clear selection"
+      >
+        <X size={14} />
+      </Button>
+    </div>
+  )
+}

--- a/frontend/src/hooks/use-bulk-select.js
+++ b/frontend/src/hooks/use-bulk-select.js
@@ -1,0 +1,52 @@
+import { useState, useCallback } from 'react'
+
+export function useBulkSelect() {
+  const [selectedIds, setSelectedIds] = useState(new Set())
+
+  const toggleRow = useCallback((id) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }, [])
+
+  const toggleAll = useCallback((ids) => {
+    setSelectedIds((prev) => {
+      const allSelected = ids.length > 0 && ids.every((id) => prev.has(id))
+      if (allSelected) return new Set()
+      return new Set(ids)
+    })
+  }, [])
+
+  const clearSelection = useCallback(() => {
+    setSelectedIds(new Set())
+  }, [])
+
+  const isSelected = useCallback((id) => selectedIds.has(id), [selectedIds])
+
+  const isAllSelected = useCallback(
+    (ids) => ids.length > 0 && ids.every((id) => selectedIds.has(id)),
+    [selectedIds]
+  )
+
+  const isIndeterminate = useCallback(
+    (ids) => ids.some((id) => selectedIds.has(id)) && !ids.every((id) => selectedIds.has(id)),
+    [selectedIds]
+  )
+
+  return {
+    selectedIds,
+    selectedCount: selectedIds.size,
+    toggleRow,
+    toggleAll,
+    clearSelection,
+    isSelected,
+    isAllSelected,
+    isIndeterminate,
+  }
+}

--- a/frontend/src/pages/accounts/AccountList.jsx
+++ b/frontend/src/pages/accounts/AccountList.jsx
@@ -25,6 +25,8 @@ import {
 import { useSortableTable, SortIcon } from '../../hooks/use-sortable-table.jsx'
 import { usePagination } from '../../hooks/use-pagination.js'
 import { Pagination } from '../../components/ui/pagination.jsx'
+import { useBulkSelect } from '../../hooks/use-bulk-select.js'
+import { BulkActionBar } from '../../components/BulkActionBar.jsx'
 
 export default function AccountList() {
   const navigate = useNavigate()
@@ -32,6 +34,7 @@ export default function AccountList() {
   const [sheetOpen, setSheetOpen] = useState(false)
   const [editAccountId, setEditAccountId] = useState(null)
   const [deleteTarget, setDeleteTarget] = useState(null)
+  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false)
 
   const { data: accounts = [], isLoading, error } = useQuery({
     queryKey: ['accounts'],
@@ -46,8 +49,20 @@ export default function AccountList() {
     },
   })
 
+  const bulkDeleteMutation = useMutation({
+    mutationFn: (ids) => Promise.all([...ids].map((id) => accountsApi.delete(id))),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['accounts'] })
+      clearSelection()
+      setBulkDeleteOpen(false)
+    },
+  })
+
   const { sortedData: sortedAccounts, sortKey, sortDir, handleSort } = useSortableTable(accounts, 'name')
   const pagination = usePagination(sortedAccounts)
+
+  const allPageIds = pagination.paginatedData.map((a) => a.accountId)
+  const { selectedIds, selectedCount, toggleRow, toggleAll, clearSelection, isSelected, isAllSelected, isIndeterminate } = useBulkSelect()
 
   return (
     <div>
@@ -66,9 +81,31 @@ export default function AccountList() {
         <p className="text-sm text-gray-400 py-4">No accounts found.</p>
       ) : (
         <Card className="p-0 overflow-hidden">
+          <BulkActionBar selectedCount={selectedCount} onClearSelection={clearSelection}>
+            <Button
+              size="sm"
+              variant="destructive"
+              className="h-7 text-xs"
+              onClick={() => setBulkDeleteOpen(true)}
+              disabled={bulkDeleteMutation.isPending}
+            >
+              Delete selected
+            </Button>
+          </BulkActionBar>
+
           <Table>
             <TableHeader>
               <TableRow>
+                <TableHead className="w-10">
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 rounded border-gray-300 accent-blue-600 cursor-pointer"
+                    checked={isAllSelected(allPageIds)}
+                    ref={(el) => { if (el) el.indeterminate = isIndeterminate(allPageIds) }}
+                    onChange={() => toggleAll(allPageIds)}
+                    aria-label="Select all"
+                  />
+                </TableHead>
                 <TableHead className="cursor-pointer select-none" onClick={() => handleSort('name')}>
                   Name <SortIcon active={sortKey === 'name'} dir={sortDir} />
                 </TableHead>
@@ -86,59 +123,72 @@ export default function AccountList() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {pagination.paginatedData.map((a) => (
-                <TableRow
-                  key={a.accountId}
-                  className="cursor-pointer group"
-                  onClick={() => navigate(`/accounts/${a.accountId}`)}
-                >
-                  <TableCell className="font-medium">
-                    <Link
-                      to={`/accounts/${a.accountId}`}
-                      className="text-blue-600 hover:underline no-underline"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      {a.name}
-                    </Link>
-                  </TableCell>
-                  <TableCell>{a.industry ?? '—'}</TableCell>
-                  <TableCell>{a.size ?? '—'}</TableCell>
-                  <TableCell>
-                    {a.website
-                      ? <a href={a.website} target="_blank" rel="noreferrer" onClick={(e) => e.stopPropagation()} className="text-blue-600 hover:underline">{a.website}</a>
-                      : '—'}
-                  </TableCell>
-                  <TableCell>{new Date(a.createdAt).toLocaleDateString()}</TableCell>
-                  <TableCell>
-                    <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity justify-end">
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        className="h-7 w-7"
-                        onClick={(e) => { e.stopPropagation(); setEditAccountId(a.accountId) }}
-                        title="Edit"
+              {pagination.paginatedData.map((a) => {
+                const selected = isSelected(a.accountId)
+                return (
+                  <TableRow
+                    key={a.accountId}
+                    className={`cursor-pointer group${selected ? ' bg-blue-50' : ''}`}
+                    onClick={() => navigate(`/accounts/${a.accountId}`)}
+                    data-state={selected ? 'selected' : undefined}
+                  >
+                    <TableCell onClick={(e) => e.stopPropagation()}>
+                      <input
+                        type="checkbox"
+                        className="h-4 w-4 rounded border-gray-300 accent-blue-600 cursor-pointer"
+                        checked={selected}
+                        onChange={() => toggleRow(a.accountId)}
+                        aria-label={`Select ${a.name}`}
+                      />
+                    </TableCell>
+                    <TableCell className="font-medium">
+                      <Link
+                        to={`/accounts/${a.accountId}`}
+                        className="text-blue-600 hover:underline no-underline"
+                        onClick={(e) => e.stopPropagation()}
                       >
-                        <Pencil size={13} />
-                      </Button>
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        className="h-7 w-7 text-red-500 hover:text-red-600 hover:bg-red-50"
-                        onClick={(e) => { e.stopPropagation(); setDeleteTarget(a) }}
-                        title="Delete"
-                      >
-                        <Trash2 size={13} />
-                      </Button>
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ))}
+                        {a.name}
+                      </Link>
+                    </TableCell>
+                    <TableCell>{a.industry ?? '—'}</TableCell>
+                    <TableCell>{a.size ?? '—'}</TableCell>
+                    <TableCell>
+                      {a.website
+                        ? <a href={a.website} target="_blank" rel="noreferrer" onClick={(e) => e.stopPropagation()} className="text-blue-600 hover:underline">{a.website}</a>
+                        : '—'}
+                    </TableCell>
+                    <TableCell>{new Date(a.createdAt).toLocaleDateString()}</TableCell>
+                    <TableCell>
+                      <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity justify-end">
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="h-7 w-7"
+                          onClick={(e) => { e.stopPropagation(); setEditAccountId(a.accountId) }}
+                          title="Edit"
+                        >
+                          <Pencil size={13} />
+                        </Button>
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="h-7 w-7 text-red-500 hover:text-red-600 hover:bg-red-50"
+                          onClick={(e) => { e.stopPropagation(); setDeleteTarget(a) }}
+                          title="Delete"
+                        >
+                          <Trash2 size={13} />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
             </TableBody>
           </Table>
           <Pagination
             {...pagination}
-            onPageChange={pagination.handlePageChange}
-            onPageSizeChange={pagination.handlePageSizeChange}
+            onPageChange={(page) => { pagination.handlePageChange(page); clearSelection() }}
+            onPageSizeChange={(size) => { pagination.handlePageSizeChange(size); clearSelection() }}
           />
         </Card>
       )}
@@ -182,7 +232,7 @@ export default function AccountList() {
         </SheetContent>
       </Sheet>
 
-      {/* Delete Confirmation Dialog */}
+      {/* Single Delete Confirmation Dialog */}
       <Dialog open={!!deleteTarget} onOpenChange={(open) => { if (!open) setDeleteTarget(null) }}>
         <DialogContent className="sm:max-w-sm">
           <DialogHeader>
@@ -202,6 +252,31 @@ export default function AccountList() {
               onClick={() => deleteMutation.mutate(deleteTarget.accountId)}
             >
               {deleteMutation.isPending ? 'Deleting…' : 'Delete'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Bulk Delete Confirmation Dialog */}
+      <Dialog open={bulkDeleteOpen} onOpenChange={(open) => { if (!open) setBulkDeleteOpen(false) }}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Delete {selectedCount} Account{selectedCount !== 1 ? 's' : ''}</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete <strong>{selectedCount}</strong> selected account{selectedCount !== 1 ? 's' : ''}?
+              This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setBulkDeleteOpen(false)} disabled={bulkDeleteMutation.isPending}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={bulkDeleteMutation.isPending}
+              onClick={() => bulkDeleteMutation.mutate(selectedIds)}
+            >
+              {bulkDeleteMutation.isPending ? 'Deleting…' : `Delete ${selectedCount}`}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/pages/activities/TaskList.jsx
+++ b/frontend/src/pages/activities/TaskList.jsx
@@ -28,6 +28,8 @@ import {
 import { useSortableTable, SortIcon } from '../../hooks/use-sortable-table.jsx'
 import { usePagination } from '../../hooks/use-pagination.js'
 import { Pagination } from '../../components/ui/pagination.jsx'
+import { useBulkSelect } from '../../hooks/use-bulk-select.js'
+import { BulkActionBar } from '../../components/BulkActionBar.jsx'
 
 function formatDate(iso) {
   if (!iso) return '—'
@@ -111,6 +113,7 @@ export default function TaskList() {
   const queryClient = useQueryClient()
   const [editTask, setEditTask] = useState(null)
   const [deleteTarget, setDeleteTarget] = useState(null)
+  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false)
 
   const { data: tasks = [], isLoading, error } = useQuery({
     queryKey: ['tasks', user?.userId],
@@ -131,6 +134,24 @@ export default function TaskList() {
     },
   })
 
+  const bulkDeleteMutation = useMutation({
+    mutationFn: (ids) => Promise.all([...ids].map((id) => activitiesApi.delete(id))),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['tasks', user?.userId] })
+      clearSelection()
+      setBulkDeleteOpen(false)
+    },
+  })
+
+  const bulkCompleteMutation = useMutation({
+    mutationFn: (ids) =>
+      Promise.all([...ids].map((id) => activitiesApi.update(id, { completedAt: new Date().toISOString() }))),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['tasks', user?.userId] })
+      clearSelection()
+    },
+  })
+
   const incompleteTasks = tasks.filter((t) => !t.completedAt)
   const completedTasks = tasks.filter((t) => t.completedAt)
 
@@ -138,6 +159,11 @@ export default function TaskList() {
   const { sortedData: sortedCompleted, sortKey: compSortKey, sortDir: compSortDir, handleSort: handleCompSort } = useSortableTable(completedTasks, 'completedAt', 'desc')
   const incompletePagination = usePagination(sortedIncomplete)
   const completedPagination = usePagination(sortedCompleted)
+
+  const allIncompletePageIds = incompletePagination.paginatedData.map((t) => t.activityId)
+  const { selectedIds, selectedCount, toggleRow, toggleAll, clearSelection, isSelected, isAllSelected, isIndeterminate } = useBulkSelect()
+
+  const isBulkBusy = bulkDeleteMutation.isPending || bulkCompleteMutation.isPending
 
   if (isLoading) {
     return (
@@ -169,9 +195,40 @@ export default function TaskList() {
         </Card>
       ) : (
         <Card className="p-0 overflow-hidden mb-6">
+          <BulkActionBar selectedCount={selectedCount} onClearSelection={clearSelection}>
+            <Button
+              size="sm"
+              variant="destructive"
+              className="h-7 text-xs"
+              onClick={() => setBulkDeleteOpen(true)}
+              disabled={isBulkBusy}
+            >
+              Delete selected
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 text-xs"
+              onClick={() => bulkCompleteMutation.mutate(selectedIds)}
+              disabled={isBulkBusy}
+            >
+              Mark complete
+            </Button>
+          </BulkActionBar>
+
           <Table>
             <TableHeader>
               <TableRow>
+                <TableHead className="w-10">
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 rounded border-gray-300 accent-blue-600 cursor-pointer"
+                    checked={isAllSelected(allIncompletePageIds)}
+                    ref={(el) => { if (el) el.indeterminate = isIndeterminate(allIncompletePageIds) }}
+                    onChange={() => toggleAll(allIncompletePageIds)}
+                    aria-label="Select all"
+                  />
+                </TableHead>
                 <TableHead className="cursor-pointer select-none" onClick={() => handleSort('subject')}>
                   Subject <SortIcon active={sortKey === 'subject'} dir={sortDir} />
                 </TableHead>
@@ -184,57 +241,73 @@ export default function TaskList() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {incompletePagination.paginatedData.map((t) => (
-                <TableRow key={t.activityId} className="cursor-default group">
-                  <TableCell className="font-medium">{t.subject}</TableCell>
-                  <TableCell>{formatDate(t.scheduledAt)}</TableCell>
-                  <TableCell>
-                    <span className="flex gap-2 flex-wrap">
-                      {t.contactId && <Link to={`/contacts/${t.contactId}`} className="text-blue-600 hover:underline text-xs">Contact</Link>}
-                      {t.dealId && <Link to={`/deals/${t.dealId}`} className="text-blue-600 hover:underline text-xs">Deal</Link>}
-                      {t.accountId && <Link to={`/accounts/${t.accountId}`} className="text-blue-600 hover:underline text-xs">Account</Link>}
-                      {!t.contactId && !t.dealId && !t.accountId && '—'}
-                    </span>
-                  </TableCell>
-                  <TableCell>
-                    <Button
-                      size="sm"
-                      disabled={completeMutation.isPending}
-                      onClick={() => completeMutation.mutate(t.activityId)}
-                    >
-                      Complete
-                    </Button>
-                  </TableCell>
-                  <TableCell>
-                    <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity justify-end">
+              {incompletePagination.paginatedData.map((t) => {
+                const selected = isSelected(t.activityId)
+                return (
+                  <TableRow
+                    key={t.activityId}
+                    className={`cursor-default group${selected ? ' bg-blue-50' : ''}`}
+                    data-state={selected ? 'selected' : undefined}
+                  >
+                    <TableCell>
+                      <input
+                        type="checkbox"
+                        className="h-4 w-4 rounded border-gray-300 accent-blue-600 cursor-pointer"
+                        checked={selected}
+                        onChange={() => toggleRow(t.activityId)}
+                        aria-label={`Select ${t.subject}`}
+                      />
+                    </TableCell>
+                    <TableCell className="font-medium">{t.subject}</TableCell>
+                    <TableCell>{formatDate(t.scheduledAt)}</TableCell>
+                    <TableCell>
+                      <span className="flex gap-2 flex-wrap">
+                        {t.contactId && <Link to={`/contacts/${t.contactId}`} className="text-blue-600 hover:underline text-xs">Contact</Link>}
+                        {t.dealId && <Link to={`/deals/${t.dealId}`} className="text-blue-600 hover:underline text-xs">Deal</Link>}
+                        {t.accountId && <Link to={`/accounts/${t.accountId}`} className="text-blue-600 hover:underline text-xs">Account</Link>}
+                        {!t.contactId && !t.dealId && !t.accountId && '—'}
+                      </span>
+                    </TableCell>
+                    <TableCell>
                       <Button
-                        size="icon"
-                        variant="ghost"
-                        className="h-7 w-7"
-                        onClick={() => setEditTask(t)}
-                        title="Edit"
+                        size="sm"
+                        disabled={completeMutation.isPending}
+                        onClick={() => completeMutation.mutate(t.activityId)}
                       >
-                        <Pencil size={13} />
+                        Complete
                       </Button>
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        className="h-7 w-7 text-red-500 hover:text-red-600 hover:bg-red-50"
-                        onClick={() => setDeleteTarget(t)}
-                        title="Delete"
-                      >
-                        <Trash2 size={13} />
-                      </Button>
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ))}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity justify-end">
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="h-7 w-7"
+                          onClick={() => setEditTask(t)}
+                          title="Edit"
+                        >
+                          <Pencil size={13} />
+                        </Button>
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="h-7 w-7 text-red-500 hover:text-red-600 hover:bg-red-50"
+                          onClick={() => setDeleteTarget(t)}
+                          title="Delete"
+                        >
+                          <Trash2 size={13} />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
             </TableBody>
           </Table>
           <Pagination
             {...incompletePagination}
-            onPageChange={incompletePagination.handlePageChange}
-            onPageSizeChange={incompletePagination.handlePageSizeChange}
+            onPageChange={(page) => { incompletePagination.handlePageChange(page); clearSelection() }}
+            onPageSizeChange={(size) => { incompletePagination.handlePageSizeChange(size); clearSelection() }}
           />
         </Card>
       )}
@@ -315,7 +388,7 @@ export default function TaskList() {
         </SheetContent>
       </Sheet>
 
-      {/* Delete Confirmation Dialog */}
+      {/* Single Delete Confirmation Dialog */}
       <Dialog open={!!deleteTarget} onOpenChange={(open) => { if (!open) setDeleteTarget(null) }}>
         <DialogContent className="sm:max-w-sm">
           <DialogHeader>
@@ -335,6 +408,31 @@ export default function TaskList() {
               onClick={() => deleteMutation.mutate(deleteTarget.activityId)}
             >
               {deleteMutation.isPending ? 'Deleting…' : 'Delete'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Bulk Delete Confirmation Dialog */}
+      <Dialog open={bulkDeleteOpen} onOpenChange={(open) => { if (!open) setBulkDeleteOpen(false) }}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Delete {selectedCount} Task{selectedCount !== 1 ? 's' : ''}</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete <strong>{selectedCount}</strong> selected task{selectedCount !== 1 ? 's' : ''}?
+              This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setBulkDeleteOpen(false)} disabled={bulkDeleteMutation.isPending}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={bulkDeleteMutation.isPending}
+              onClick={() => bulkDeleteMutation.mutate(selectedIds)}
+            >
+              {bulkDeleteMutation.isPending ? 'Deleting…' : `Delete ${selectedCount}`}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/pages/contacts/ContactList.jsx
+++ b/frontend/src/pages/contacts/ContactList.jsx
@@ -34,6 +34,8 @@ import {
 import { useSortableTable, SortIcon } from '../../hooks/use-sortable-table.jsx'
 import { usePagination } from '../../hooks/use-pagination.js'
 import { Pagination } from '../../components/ui/pagination.jsx'
+import { useBulkSelect } from '../../hooks/use-bulk-select.js'
+import { BulkActionBar } from '../../components/BulkActionBar.jsx'
 
 const STATUSES = ['Lead', 'Prospect', 'Customer', 'Churned']
 
@@ -52,6 +54,7 @@ export default function ContactList() {
   const [sheetOpen, setSheetOpen] = useState(false)
   const [editContactId, setEditContactId] = useState(null)
   const [deleteTarget, setDeleteTarget] = useState(null)
+  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false)
 
   const { data: contacts = [], isLoading, error } = useQuery({
     queryKey: ['contacts', { status: statusFilter, ownerId: ownerFilter }],
@@ -71,8 +74,29 @@ export default function ContactList() {
     },
   })
 
+  const bulkDeleteMutation = useMutation({
+    mutationFn: (ids) => Promise.all([...ids].map((id) => contactsApi.delete(id))),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['contacts'] })
+      clearSelection()
+      setBulkDeleteOpen(false)
+    },
+  })
+
+  const bulkStatusMutation = useMutation({
+    mutationFn: ({ ids, status }) =>
+      Promise.all([...ids].map((id) => contactsApi.update(id, { status }))),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['contacts'] })
+      clearSelection()
+    },
+  })
+
   const { sortedData: sortedContacts, sortKey, sortDir, handleSort } = useSortableTable(contacts, 'lastName')
   const pagination = usePagination(sortedContacts)
+
+  const allPageIds = pagination.paginatedData.map((c) => c.contactId)
+  const { selectedIds, selectedCount, toggleRow, toggleAll, clearSelection, isSelected, isAllSelected, isIndeterminate } = useBulkSelect()
 
   return (
     <div>
@@ -83,7 +107,7 @@ export default function ContactList() {
 
       {/* Filters */}
       <div className="flex gap-3 mb-4">
-        <Select value={statusFilter} onValueChange={(v) => setStatusFilter(v === '_all' ? '' : v)}>
+        <Select value={statusFilter} onValueChange={(v) => { setStatusFilter(v === '_all' ? '' : v); clearSelection() }}>
           <SelectTrigger className="w-44">
             <SelectValue placeholder="All statuses" />
           </SelectTrigger>
@@ -93,7 +117,7 @@ export default function ContactList() {
           </SelectContent>
         </Select>
 
-        <Select value={ownerFilter} onValueChange={(v) => setOwnerFilter(v === '_all' ? '' : v)}>
+        <Select value={ownerFilter} onValueChange={(v) => { setOwnerFilter(v === '_all' ? '' : v); clearSelection() }}>
           <SelectTrigger className="w-44">
             <SelectValue placeholder="All owners" />
           </SelectTrigger>
@@ -118,9 +142,43 @@ export default function ContactList() {
         <p className="text-sm text-gray-400 py-4">No contacts found.</p>
       ) : (
         <Card className="p-0 overflow-hidden">
+          <BulkActionBar selectedCount={selectedCount} onClearSelection={clearSelection}>
+            <Button
+              size="sm"
+              variant="destructive"
+              className="h-7 text-xs"
+              onClick={() => setBulkDeleteOpen(true)}
+              disabled={bulkDeleteMutation.isPending || bulkStatusMutation.isPending}
+            >
+              Delete selected
+            </Button>
+            <Select
+              value=""
+              onValueChange={(status) => bulkStatusMutation.mutate({ ids: selectedIds, status })}
+              disabled={bulkDeleteMutation.isPending || bulkStatusMutation.isPending}
+            >
+              <SelectTrigger className="h-7 w-44 text-xs">
+                <SelectValue placeholder="Change status…" />
+              </SelectTrigger>
+              <SelectContent>
+                {STATUSES.map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}
+              </SelectContent>
+            </Select>
+          </BulkActionBar>
+
           <Table>
             <TableHeader>
               <TableRow>
+                <TableHead className="w-10">
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 rounded border-gray-300 accent-blue-600 cursor-pointer"
+                    checked={isAllSelected(allPageIds)}
+                    ref={(el) => { if (el) el.indeterminate = isIndeterminate(allPageIds) }}
+                    onChange={() => toggleAll(allPageIds)}
+                    aria-label="Select all"
+                  />
+                </TableHead>
                 <TableHead className="cursor-pointer select-none" onClick={() => handleSort('lastName')}>
                   Name <SortIcon active={sortKey === 'lastName'} dir={sortDir} />
                 </TableHead>
@@ -140,12 +198,23 @@ export default function ContactList() {
             <TableBody>
               {pagination.paginatedData.map((c) => {
                 const owner = team.find((m) => m.userId === c.ownerId)
+                const selected = isSelected(c.contactId)
                 return (
                   <TableRow
                     key={c.contactId}
-                    className="cursor-pointer group"
+                    className={`cursor-pointer group${selected ? ' bg-blue-50' : ''}`}
                     onClick={() => navigate(`/contacts/${c.contactId}`)}
+                    data-state={selected ? 'selected' : undefined}
                   >
+                    <TableCell onClick={(e) => e.stopPropagation()}>
+                      <input
+                        type="checkbox"
+                        className="h-4 w-4 rounded border-gray-300 accent-blue-600 cursor-pointer"
+                        checked={selected}
+                        onChange={() => toggleRow(c.contactId)}
+                        aria-label={`Select ${c.firstName} ${c.lastName}`}
+                      />
+                    </TableCell>
                     <TableCell className="font-medium">
                       <Link
                         to={`/contacts/${c.contactId}`}
@@ -192,8 +261,8 @@ export default function ContactList() {
           </Table>
           <Pagination
             {...pagination}
-            onPageChange={pagination.handlePageChange}
-            onPageSizeChange={pagination.handlePageSizeChange}
+            onPageChange={(page) => { pagination.handlePageChange(page); clearSelection() }}
+            onPageSizeChange={(size) => { pagination.handlePageSizeChange(size); clearSelection() }}
           />
         </Card>
       )}
@@ -237,7 +306,7 @@ export default function ContactList() {
         </SheetContent>
       </Sheet>
 
-      {/* Delete Confirmation Dialog */}
+      {/* Single Delete Confirmation Dialog */}
       <Dialog open={!!deleteTarget} onOpenChange={(open) => { if (!open) setDeleteTarget(null) }}>
         <DialogContent className="sm:max-w-sm">
           <DialogHeader>
@@ -258,6 +327,31 @@ export default function ContactList() {
               onClick={() => deleteMutation.mutate(deleteTarget.contactId)}
             >
               {deleteMutation.isPending ? 'Deleting…' : 'Delete'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Bulk Delete Confirmation Dialog */}
+      <Dialog open={bulkDeleteOpen} onOpenChange={(open) => { if (!open) setBulkDeleteOpen(false) }}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Delete {selectedCount} Contact{selectedCount !== 1 ? 's' : ''}</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete <strong>{selectedCount}</strong> selected contact{selectedCount !== 1 ? 's' : ''}?
+              This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setBulkDeleteOpen(false)} disabled={bulkDeleteMutation.isPending}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={bulkDeleteMutation.isPending}
+              onClick={() => bulkDeleteMutation.mutate(selectedIds)}
+            >
+              {bulkDeleteMutation.isPending ? 'Deleting…' : `Delete ${selectedCount}`}
             </Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
Closes #9

Adds checkbox-based bulk selection to ContactList, AccountList, and TaskList.

## Changes
- New `useBulkSelect` hook for selection state management
- New `BulkActionBar` component shown when rows are selected
- ContactList: bulk delete + bulk status change
- AccountList: bulk delete
- TaskList: bulk delete + bulk mark complete

Generated with [Claude Code](https://claude.ai/code)