### PR TITLE
feat: Toast notifications for form success/error feedback

### DIFF
--- a/frontend/src/components/ActivityLogForm.jsx
+++ b/frontend/src/components/ActivityLogForm.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { PlusCircle } from 'lucide-react'
 import { activitiesApi } from '../api/activities.api.js'
+import { toast } from '../hooks/use-toast.js'
 import { Button } from './ui/button.jsx'
 import { Input } from './ui/input.jsx'
 import { Textarea } from './ui/textarea.jsx'
@@ -31,7 +32,6 @@ export default function ActivityLogForm({ contactId, dealId, accountId, queryKey
   const [subject, setSubject] = useState('')
   const [notes, setNotes] = useState('')
   const [scheduledAt, setScheduledAt] = useState('')
-  const [error, setError] = useState('')
 
   const params = {}
   if (contactId) params.contactId = contactId
@@ -42,18 +42,21 @@ export default function ActivityLogForm({ contactId, dealId, accountId, queryKey
     mutationFn: (data) => activitiesApi.create(data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [queryKey ?? 'activities', params] })
+      toast({ variant: 'success', title: 'Activity logged' })
       setSubject('')
       setNotes('')
       setScheduledAt('')
-      setError('')
       setOpen(false)
     },
-    onError: (err) => setError(err.message),
+    onError: (err) => toast({ variant: 'destructive', title: 'Failed to log activity', description: err.message }),
   })
 
   function handleSubmit(e) {
     e.preventDefault()
-    if (!subject.trim()) { setError('Subject is required.'); return }
+    if (!subject.trim()) {
+      toast({ variant: 'destructive', title: 'Validation error', description: 'Subject is required.' })
+      return
+    }
     createMutation.mutate({
       type,
       subject: subject.trim(),
@@ -120,10 +123,6 @@ export default function ActivityLogForm({ contactId, dealId, accountId, queryKey
                   onChange={(e) => setScheduledAt(e.target.value)}
                 />
               </div>
-            )}
-
-            {error && (
-              <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-md">{error}</p>
             )}
 
             <SheetFooter className="mt-auto pt-4 border-t">

--- a/frontend/src/pages/accounts/AccountDetail.jsx
+++ b/frontend/src/pages/accounts/AccountDetail.jsx
@@ -28,6 +28,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from '../../components/ui/sheet.jsx'
+import { toast } from '../../hooks/use-toast.js'
 
 const STATUS_VARIANT = {
   Lead: 'lead',
@@ -58,8 +59,10 @@ export default function AccountDetail() {
     mutationFn: () => accountsApi.delete(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['accounts'] })
+      toast({ variant: 'success', title: 'Account deleted' })
       navigate('/accounts')
     },
+    onError: (err) => toast({ variant: 'destructive', title: 'Delete failed', description: err.message }),
   })
 
   if (isLoading) {

--- a/frontend/src/pages/accounts/AccountForm.jsx
+++ b/frontend/src/pages/accounts/AccountForm.jsx
@@ -14,6 +14,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../../components/ui/select.jsx'
+import { toast } from '../../hooks/use-toast.js'
 
 const INDUSTRIES = ['Technology', 'Finance', 'Healthcare', 'Retail', 'Manufacturing', 'Education', 'Other']
 const SIZES = ['Small', 'Medium', 'Large', 'Enterprise']
@@ -31,7 +32,6 @@ export default function AccountForm({ onSuccess, onClose, id: idProp }) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [fields, setFields] = useState(EMPTY)
-  const [error, setError] = useState(null)
 
   const { data: existing } = useQuery({
     queryKey: ['account', id],
@@ -61,13 +61,14 @@ export default function AccountForm({ onSuccess, onClose, id: idProp }) {
     onSuccess: (result) => {
       queryClient.invalidateQueries({ queryKey: ['accounts'] })
       if (isEdit) queryClient.invalidateQueries({ queryKey: ['account', id] })
+      toast({ variant: 'success', title: isEdit ? 'Account updated' : 'Account created' })
       if (onSuccess) {
         onSuccess(result)
       } else {
         navigate(isEdit ? `/accounts/${id}` : `/accounts/${result.accountId}`)
       }
     },
-    onError: (err) => setError(err.message),
+    onError: (err) => toast({ variant: 'destructive', title: 'Save failed', description: err.message }),
   })
 
   function set(field, value) {
@@ -76,7 +77,6 @@ export default function AccountForm({ onSuccess, onClose, id: idProp }) {
 
   function handleSubmit(e) {
     e.preventDefault()
-    setError(null)
     mutation.mutate({
       ...fields,
       industry: fields.industry || null,
@@ -103,9 +103,6 @@ export default function AccountForm({ onSuccess, onClose, id: idProp }) {
 
   const formFields = (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-      {error && (
-        <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-md border border-red-200">{error}</p>
-      )}
       <div className="flex flex-col gap-1.5">
         <Label>Name *</Label>
         <Input value={fields.name} onChange={(e) => set('name', e.target.value)} required />

--- a/frontend/src/pages/accounts/AccountList.jsx
+++ b/frontend/src/pages/accounts/AccountList.jsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Link, useNavigate } from 'react-router-dom'
 import { Pencil, Trash2 } from 'lucide-react'
 import { accountsApi } from '../../api/accounts.api.js'
+import { toast } from '../../hooks/use-toast.js'
 import AccountForm from './AccountForm.jsx'
 import { Button } from '../../components/ui/button.jsx'
 import { Skeleton } from '../../components/ui/skeleton.jsx'
@@ -45,17 +46,21 @@ export default function AccountList() {
     mutationFn: (id) => accountsApi.delete(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['accounts'] })
+      toast({ variant: 'success', title: 'Account deleted' })
       setDeleteTarget(null)
     },
+    onError: (err) => toast({ variant: 'destructive', title: 'Delete failed', description: err.message }),
   })
 
   const bulkDeleteMutation = useMutation({
     mutationFn: (ids) => Promise.all([...ids].map((id) => accountsApi.delete(id))),
-    onSuccess: () => {
+    onSuccess: (_, ids) => {
       queryClient.invalidateQueries({ queryKey: ['accounts'] })
+      toast({ variant: 'success', title: `${[...ids].length} account${[...ids].length !== 1 ? 's' : ''} deleted` })
       clearSelection()
       setBulkDeleteOpen(false)
     },
+    onError: (err) => toast({ variant: 'destructive', title: 'Bulk delete failed', description: err.message }),
   })
 
   const { sortedData: sortedAccounts, sortKey, sortDir, handleSort } = useSortableTable(accounts, 'name')

--- a/frontend/src/pages/contacts/ContactDetail.jsx
+++ b/frontend/src/pages/contacts/ContactDetail.jsx
@@ -79,8 +79,10 @@ export default function ContactDetail() {
     mutationFn: () => contactsApi.delete(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['contacts'] })
+      toast({ variant: 'success', title: 'Contact deleted' })
       navigate('/contacts')
     },
+    onError: (err) => toast({ variant: 'destructive', title: 'Delete failed', description: err.message }),
   })
 
   if (isLoading) {

--- a/frontend/src/pages/contacts/ContactForm.jsx
+++ b/frontend/src/pages/contacts/ContactForm.jsx
@@ -16,6 +16,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../../components/ui/select.jsx'
+import { toast } from '../../hooks/use-toast.js'
 
 const STATUSES = ['Lead', 'Prospect', 'Customer', 'Churned']
 const EMPTY = { firstName: '', lastName: '', email: '', phone: '', status: 'Lead', accountId: '', ownerId: '' }
@@ -28,7 +29,6 @@ export default function ContactForm({ onSuccess, onClose, id: idProp }) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [fields, setFields] = useState(EMPTY)
-  const [error, setError] = useState(null)
 
   const { data: existing } = useQuery({
     queryKey: ['contact', id],
@@ -66,13 +66,14 @@ export default function ContactForm({ onSuccess, onClose, id: idProp }) {
     onSuccess: (result) => {
       queryClient.invalidateQueries({ queryKey: ['contacts'] })
       if (isEdit) queryClient.invalidateQueries({ queryKey: ['contact', id] })
+      toast({ variant: 'success', title: isEdit ? 'Contact updated' : 'Contact created' })
       if (onSuccess) {
         onSuccess(result)
       } else {
         navigate(isEdit ? `/contacts/${id}` : `/contacts/${result.contactId}`)
       }
     },
-    onError: (err) => setError(err.message),
+    onError: (err) => toast({ variant: 'destructive', title: 'Save failed', description: err.message }),
   })
 
   function set(field, value) {
@@ -81,7 +82,6 @@ export default function ContactForm({ onSuccess, onClose, id: idProp }) {
 
   function handleSubmit(e) {
     e.preventDefault()
-    setError(null)
     mutation.mutate({
       ...fields,
       accountId: fields.accountId || null,
@@ -102,9 +102,6 @@ export default function ContactForm({ onSuccess, onClose, id: idProp }) {
 
   const formFields = (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-      {error && (
-        <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-md border border-red-200">{error}</p>
-      )}
       <div className="grid grid-cols-2 gap-4">
         <div className="flex flex-col gap-1.5">
           <Label>First Name *</Label>

--- a/frontend/src/pages/contacts/ContactList.jsx
+++ b/frontend/src/pages/contacts/ContactList.jsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Link, useNavigate } from 'react-router-dom'
 import { Pencil, Trash2 } from 'lucide-react'
 import { contactsApi } from '../../api/contacts.api.js'
+import { toast } from '../../hooks/use-toast.js'
 import { usersApi } from '../../api/users.api.js'
 import ContactForm from './ContactForm.jsx'
 import { Button } from '../../components/ui/button.jsx'
@@ -70,26 +71,32 @@ export default function ContactList() {
     mutationFn: (id) => contactsApi.delete(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['contacts'] })
+      toast({ variant: 'success', title: 'Contact deleted' })
       setDeleteTarget(null)
     },
+    onError: (err) => toast({ variant: 'destructive', title: 'Delete failed', description: err.message }),
   })
 
   const bulkDeleteMutation = useMutation({
     mutationFn: (ids) => Promise.all([...ids].map((id) => contactsApi.delete(id))),
-    onSuccess: () => {
+    onSuccess: (_, ids) => {
       queryClient.invalidateQueries({ queryKey: ['contacts'] })
+      toast({ variant: 'success', title: `${[...ids].length} contact${[...ids].length !== 1 ? 's' : ''} deleted` })
       clearSelection()
       setBulkDeleteOpen(false)
     },
+    onError: (err) => toast({ variant: 'destructive', title: 'Bulk delete failed', description: err.message }),
   })
 
   const bulkStatusMutation = useMutation({
     mutationFn: ({ ids, status }) =>
       Promise.all([...ids].map((id) => contactsApi.update(id, { status }))),
-    onSuccess: () => {
+    onSuccess: (_, { ids, status }) => {
       queryClient.invalidateQueries({ queryKey: ['contacts'] })
+      toast({ variant: 'success', title: `Status updated to ${status}`, description: `${[...ids].length} contact${[...ids].length !== 1 ? 's' : ''} updated` })
       clearSelection()
     },
+    onError: (err) => toast({ variant: 'destructive', title: 'Status update failed', description: err.message }),
   })
 
   const { sortedData: sortedContacts, sortKey, sortDir, handleSort } = useSortableTable(contacts, 'lastName')

--- a/frontend/src/pages/deals/DealDetail.jsx
+++ b/frontend/src/pages/deals/DealDetail.jsx
@@ -36,6 +36,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from '../../components/ui/sheet.jsx'
+import { toast } from '../../hooks/use-toast.js'
 
 const STAGES = ['Prospecting', 'Proposal', 'Negotiation', 'ClosedWon', 'ClosedLost']
 const ROLES = ['DecisionMaker', 'Influencer', 'Champion']
@@ -66,25 +67,39 @@ export default function DealDetail() {
 
   const stageUpdate = useMutation({
     mutationFn: (stage) => dealsApi.update(id, { stage }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['deal', id] }),
+    onSuccess: (_, stage) => {
+      queryClient.invalidateQueries({ queryKey: ['deal', id] })
+      toast({ variant: 'success', title: 'Stage updated', description: `Deal moved to ${stage}` })
+    },
+    onError: (err) => toast({ variant: 'destructive', title: 'Update failed', description: err.message }),
   })
 
   const deleteDeal = useMutation({
     mutationFn: () => dealsApi.delete(id),
-    onSuccess: () => navigate('/deals'),
+    onSuccess: () => {
+      toast({ variant: 'success', title: 'Deal deleted' })
+      navigate('/deals')
+    },
+    onError: (err) => toast({ variant: 'destructive', title: 'Delete failed', description: err.message }),
   })
 
   const addContact = useMutation({
     mutationFn: () => dealsApi.addContact(id, { contactId, role: contactRole }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['deal', id] })
+      toast({ variant: 'success', title: 'Contact added' })
       setContactId('')
     },
+    onError: (err) => toast({ variant: 'destructive', title: 'Failed to add contact', description: err.message }),
   })
 
   const removeContact = useMutation({
     mutationFn: (cid) => dealsApi.removeContact(id, cid),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['deal', id] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['deal', id] })
+      toast({ variant: 'success', title: 'Contact removed' })
+    },
+    onError: (err) => toast({ variant: 'destructive', title: 'Failed to remove contact', description: err.message }),
   })
 
   if (isLoading) {

--- a/frontend/src/pages/deals/DealForm.jsx
+++ b/frontend/src/pages/deals/DealForm.jsx
@@ -16,6 +16,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../../components/ui/select.jsx'
+import { toast } from '../../hooks/use-toast.js'
 
 const STAGES = ['Prospecting', 'Proposal', 'Negotiation', 'ClosedWon', 'ClosedLost']
 
@@ -36,7 +37,6 @@ export default function DealForm({ onSuccess, onClose, id: idProp }) {
     expectedCloseDate: '',
     ownerId: '',
   })
-  const [error, setError] = useState('')
 
   const { data: existing } = useQuery({
     queryKey: ['deal', id],
@@ -73,13 +73,14 @@ export default function DealForm({ onSuccess, onClose, id: idProp }) {
     onSuccess: (deal) => {
       queryClient.invalidateQueries({ queryKey: ['pipeline'] })
       queryClient.invalidateQueries({ queryKey: ['deals'] })
+      toast({ variant: 'success', title: isEdit ? 'Deal updated' : 'Deal created' })
       if (onSuccess) {
         onSuccess(deal)
       } else {
         navigate(isEdit ? `/deals/${id}` : `/deals/${deal.dealId}`)
       }
     },
-    onError: (err) => setError(err.message),
+    onError: (err) => toast({ variant: 'destructive', title: 'Save failed', description: err.message }),
   })
 
   const set = (field) => (e) => setForm((f) => ({ ...f, [field]: e.target.value }))
@@ -87,8 +88,10 @@ export default function DealForm({ onSuccess, onClose, id: idProp }) {
 
   const handleSubmit = (e) => {
     e.preventDefault()
-    if (!form.title.trim()) { setError('Title is required.'); return }
-    setError('')
+    if (!form.title.trim()) {
+      toast({ variant: 'destructive', title: 'Validation error', description: 'Title is required.' })
+      return
+    }
     mutation.mutate({
       title: form.title,
       accountId: form.accountId || undefined,
@@ -113,10 +116,6 @@ export default function DealForm({ onSuccess, onClose, id: idProp }) {
 
   const formFields = (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-      {error && (
-        <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-md border border-red-200">{error}</p>
-      )}
-
       <div className="flex flex-col gap-1.5">
         <Label>Title *</Label>
         <Input value={form.title} onChange={set('title')} required />


### PR DESCRIPTION
Replace inline form-level success/error messages with shadcn/ui toast notifications.

## Changes
- Removed inline `<p>` error elements from ContactForm, AccountForm, DealForm, ActivityLogForm
- Added non-blocking auto-dismissing toasts for all create/edit/delete/bulk operations
- Uses existing shadcn/ui Toaster (already mounted in main.jsx) with success/destructive variants
- Covers: ContactForm, AccountForm, DealForm, ActivityLogForm, ContactDetail, AccountDetail, DealDetail, ContactList, AccountList

Closes #10

Generated with [Claude Code](https://claude.ai/code)