### PR TITLE
feat: upgrade loading states to content-shaped skeleton screens

### DIFF
--- a/frontend/src/pages/accounts/AccountDetail.jsx
+++ b/frontend/src/pages/accounts/AccountDetail.jsx
@@ -68,8 +68,35 @@ export default function AccountDetail() {
   if (isLoading) {
     return (
       <div className="flex flex-col gap-4">
-        <Skeleton className="h-8 w-56" />
-        <Skeleton className="h-48 w-full rounded-lg" />
+        <Skeleton className="h-4 w-44" />
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-8 w-48" />
+          <div className="flex gap-2">
+            <Skeleton className="h-9 w-16 rounded-md" />
+            <Skeleton className="h-9 w-16 rounded-md" />
+          </div>
+        </div>
+        <Card>
+          <CardHeader><Skeleton className="h-5 w-16" /></CardHeader>
+          <CardContent className="pt-0">
+            <div className="flex flex-col gap-4">
+              {['Industry', 'Size', 'Website', 'Address', 'Created', 'Updated'].map((field) => (
+                <div key={field} className="flex gap-4">
+                  <Skeleton className="h-4 w-28 flex-shrink-0" />
+                  <Skeleton className="h-4 flex-1 max-w-xs" />
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader><Skeleton className="h-5 w-28" /></CardHeader>
+          <CardContent className="pt-0">
+            <div className="flex flex-col gap-3">
+              {[1, 2].map((i) => <Skeleton key={i} className="h-10 w-full rounded-md" />)}
+            </div>
+          </CardContent>
+        </Card>
       </div>
     )
   }

--- a/frontend/src/pages/accounts/AccountList.jsx
+++ b/frontend/src/pages/accounts/AccountList.jsx
@@ -77,8 +77,33 @@ export default function AccountList() {
       </div>
 
       {isLoading ? (
-        <Card className="p-4 flex flex-col gap-3">
-          {[1, 2, 3].map((i) => <Skeleton key={i} className="h-10 w-full" />)}
+        <Card className="p-0 overflow-hidden">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-10"><Skeleton className="h-4 w-4" /></TableHead>
+                <TableHead><Skeleton className="h-4 w-16" /></TableHead>
+                <TableHead><Skeleton className="h-4 w-20" /></TableHead>
+                <TableHead><Skeleton className="h-4 w-12" /></TableHead>
+                <TableHead><Skeleton className="h-4 w-20" /></TableHead>
+                <TableHead><Skeleton className="h-4 w-18" /></TableHead>
+                <TableHead className="w-20" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {[1, 2, 3, 4, 5].map((i) => (
+                <TableRow key={i}>
+                  <TableCell><Skeleton className="h-4 w-4" /></TableCell>
+                  <TableCell><Skeleton className="h-4 w-36" /></TableCell>
+                  <TableCell><Skeleton className="h-4 w-24" /></TableCell>
+                  <TableCell><Skeleton className="h-4 w-16" /></TableCell>
+                  <TableCell><Skeleton className="h-4 w-32" /></TableCell>
+                  <TableCell><Skeleton className="h-4 w-20" /></TableCell>
+                  <TableCell />
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
         </Card>
       ) : error ? (
         <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-md">{error.message}</p>

--- a/frontend/src/pages/activities/TaskList.jsx
+++ b/frontend/src/pages/activities/TaskList.jsx
@@ -171,8 +171,31 @@ export default function TaskList() {
         <div className="flex items-center justify-between mb-5">
           <h1 className="text-2xl font-bold text-gray-900">My Tasks</h1>
         </div>
-        <Card className="p-4 flex flex-col gap-3">
-          {[1, 2, 3].map((i) => <Skeleton key={i} className="h-12 w-full" />)}
+        <Card className="p-0 overflow-hidden">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-10"><Skeleton className="h-4 w-4" /></TableHead>
+                <TableHead><Skeleton className="h-4 w-20" /></TableHead>
+                <TableHead><Skeleton className="h-4 w-24" /></TableHead>
+                <TableHead><Skeleton className="h-4 w-20" /></TableHead>
+                <TableHead><Skeleton className="h-4 w-20" /></TableHead>
+                <TableHead className="w-20" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {[1, 2, 3, 4, 5].map((i) => (
+                <TableRow key={i}>
+                  <TableCell><Skeleton className="h-4 w-4" /></TableCell>
+                  <TableCell><Skeleton className="h-4 w-48" /></TableCell>
+                  <TableCell><Skeleton className="h-4 w-28" /></TableCell>
+                  <TableCell><Skeleton className="h-4 w-20" /></TableCell>
+                  <TableCell><Skeleton className="h-7 w-20 rounded-md" /></TableCell>
+                  <TableCell />
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
         </Card>
       </div>
     )

--- a/frontend/src/pages/contacts/ContactDetail.jsx
+++ b/frontend/src/pages/contacts/ContactDetail.jsx
@@ -88,8 +88,33 @@ export default function ContactDetail() {
   if (isLoading) {
     return (
       <div className="flex flex-col gap-4">
-        <Skeleton className="h-8 w-64" />
-        <Skeleton className="h-48 w-full rounded-lg" />
+        <Skeleton className="h-4 w-48" />
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-8 w-56" />
+          <div className="flex gap-2">
+            <Skeleton className="h-9 w-16 rounded-md" />
+            <Skeleton className="h-9 w-16 rounded-md" />
+          </div>
+        </div>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex flex-col gap-4">
+              {['Status', 'Email', 'Phone', 'Account', 'Owner', 'Created', 'Updated'].map((field) => (
+                <div key={field} className="flex gap-4">
+                  <Skeleton className="h-4 w-28 flex-shrink-0" />
+                  <Skeleton className="h-4 flex-1 max-w-xs" />
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex flex-col gap-3">
+              {[1, 2, 3].map((i) => <Skeleton key={i} className="h-16 w-full rounded-lg" />)}
+            </div>
+          </CardContent>
+        </Card>
       </div>
     )
   }

--- a/frontend/src/pages/contacts/ContactList.jsx
+++ b/frontend/src/pages/contacts/ContactList.jsx
@@ -139,9 +139,32 @@ export default function ContactList() {
 
       {isLoading ? (
         <Card className="p-0 overflow-hidden">
-          <div className="p-4 flex flex-col gap-3">
-            {[1, 2, 3, 4].map((i) => <Skeleton key={i} className="h-10 w-full" />)}
-          </div>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-10"><Skeleton className="h-4 w-4" /></TableHead>
+                <TableHead><Skeleton className="h-4 w-16" /></TableHead>
+                <TableHead><Skeleton className="h-4 w-20" /></TableHead>
+                <TableHead><Skeleton className="h-4 w-14" /></TableHead>
+                <TableHead><Skeleton className="h-4 w-14" /></TableHead>
+                <TableHead><Skeleton className="h-4 w-18" /></TableHead>
+                <TableHead className="w-20" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {[1, 2, 3, 4, 5].map((i) => (
+                <TableRow key={i}>
+                  <TableCell><Skeleton className="h-4 w-4" /></TableCell>
+                  <TableCell><Skeleton className="h-4 w-32" /></TableCell>
+                  <TableCell><Skeleton className="h-4 w-44" /></TableCell>
+                  <TableCell><Skeleton className="h-5 w-16 rounded-full" /></TableCell>
+                  <TableCell><Skeleton className="h-4 w-24" /></TableCell>
+                  <TableCell><Skeleton className="h-4 w-20" /></TableCell>
+                  <TableCell />
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
         </Card>
       ) : error ? (
         <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-md">{error.message}</p>

--- a/frontend/src/pages/deals/DealDetail.jsx
+++ b/frontend/src/pages/deals/DealDetail.jsx
@@ -105,9 +105,39 @@ export default function DealDetail() {
   if (isLoading) {
     return (
       <div className="flex flex-col gap-4 max-w-2xl">
-        <Skeleton className="h-8 w-64" />
-        <Skeleton className="h-32 w-full rounded-lg" />
-        <Skeleton className="h-48 w-full rounded-lg" />
+        <Skeleton className="h-4 w-44" />
+        <div className="flex items-start justify-between">
+          <div className="flex flex-col gap-1.5">
+            <Skeleton className="h-8 w-56" />
+            <Skeleton className="h-4 w-32" />
+          </div>
+          <div className="flex gap-2">
+            <Skeleton className="h-9 w-16 rounded-md" />
+            <Skeleton className="h-9 w-16 rounded-md" />
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          {[1, 2, 3, 4].map((i) => (
+            <Card key={i}>
+              <CardContent className="pt-4 pb-4">
+                <Skeleton className="h-3 w-24 mb-2" />
+                <Skeleton className="h-5 w-20" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+        <Card>
+          <CardHeader><Skeleton className="h-5 w-40" /></CardHeader>
+          <CardContent className="pt-0 flex flex-col gap-3">
+            {[1, 2].map((i) => (
+              <div key={i} className="flex gap-4">
+                <Skeleton className="h-4 flex-1" />
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-7 w-16 rounded-md" />
+              </div>
+            ))}
+          </CardContent>
+        </Card>
       </div>
     )
   }


### PR DESCRIPTION
Replace generic full-width skeleton blocks with content-shaped skeletons that mirror actual table columns and detail card field layouts.

- ContactList, AccountList, TaskList: table skeleton with header row and per-column width skeletons
- ContactDetail, AccountDetail: skeleton with breadcrumb, header+ actions, field rows, and activity section placeholders
- DealDetail: skeleton matching breadcrumb, header, 2x2 stat grid, and contacts card

Closes #11

Generated with [Claude Code](https://claude.ai/code)