### PR TITLE
feat: add guided empty states to all list views

### DIFF
--- a/frontend/src/components/EmptyState.jsx
+++ b/frontend/src/components/EmptyState.jsx
@@ -1,0 +1,18 @@
+import { Button } from './ui/button.jsx'
+
+export function EmptyState({ icon, heading, description, action }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 px-6 text-center">
+      <div className="flex items-center justify-center w-16 h-16 rounded-full bg-gray-100 text-gray-400 mb-4">
+        {icon}
+      </div>
+      <h3 className="text-lg font-semibold text-gray-900 mb-1">{heading}</h3>
+      {description && (
+        <p className="text-sm text-gray-500 max-w-sm mb-5">{description}</p>
+      )}
+      {action && (
+        <Button onClick={action.onClick}>{action.label}</Button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/accounts/AccountList.jsx
+++ b/frontend/src/pages/accounts/AccountList.jsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Link, useNavigate } from 'react-router-dom'
-import { Pencil, Trash2 } from 'lucide-react'
+import { Pencil, Trash2, Building2 } from 'lucide-react'
+import { EmptyState } from '../../components/EmptyState.jsx'
 import { accountsApi } from '../../api/accounts.api.js'
 import { toast } from '../../hooks/use-toast.js'
 import AccountForm from './AccountForm.jsx'
@@ -108,7 +109,12 @@ export default function AccountList() {
       ) : error ? (
         <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-md">{error.message}</p>
       ) : accounts.length === 0 ? (
-        <p className="text-sm text-gray-400 py-4">No accounts found.</p>
+        <EmptyState
+          icon={<Building2 size={28} />}
+          heading="No accounts yet"
+          description="Track the companies you work with — add your first account to get started."
+          action={{ label: '+ Add your first account', onClick: () => setSheetOpen(true) }}
+        />
       ) : (
         <Card className="p-0 overflow-hidden">
           <BulkActionBar selectedCount={selectedCount} onClearSelection={clearSelection}>

--- a/frontend/src/pages/activities/TaskList.jsx
+++ b/frontend/src/pages/activities/TaskList.jsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Link } from 'react-router-dom'
-import { Pencil, Trash2 } from 'lucide-react'
+import { Pencil, Trash2, CheckSquare } from 'lucide-react'
+import { EmptyState } from '../../components/EmptyState.jsx'
 import { activitiesApi } from '../../api/activities.api.js'
 import { useAuth } from '../../context/AuthContext.jsx'
 import { Button } from '../../components/ui/button.jsx'
@@ -9,7 +10,7 @@ import { Input } from '../../components/ui/input.jsx'
 import { Label } from '../../components/ui/label.jsx'
 import { Textarea } from '../../components/ui/textarea.jsx'
 import { Skeleton } from '../../components/ui/skeleton.jsx'
-import { Card, CardContent } from '../../components/ui/card.jsx'
+import { Card } from '../../components/ui/card.jsx'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../components/ui/table.jsx'
 import {
   Sheet,
@@ -211,11 +212,11 @@ export default function TaskList() {
       </div>
 
       {incompleteTasks.length === 0 ? (
-        <Card>
-          <CardContent className="py-6">
-            <p className="text-sm text-gray-400">No open tasks. You're all caught up.</p>
-          </CardContent>
-        </Card>
+        <EmptyState
+          icon={<CheckSquare size={28} />}
+          heading="You're all caught up!"
+          description="No open tasks. Log activities from a contact or deal to create tasks."
+        />
       ) : (
         <Card className="p-0 overflow-hidden mb-6">
           <BulkActionBar selectedCount={selectedCount} onClearSelection={clearSelection}>

--- a/frontend/src/pages/contacts/ContactList.jsx
+++ b/frontend/src/pages/contacts/ContactList.jsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Link, useNavigate } from 'react-router-dom'
-import { Pencil, Trash2 } from 'lucide-react'
+import { Pencil, Trash2, Users } from 'lucide-react'
+import { EmptyState } from '../../components/EmptyState.jsx'
 import { contactsApi } from '../../api/contacts.api.js'
 import { toast } from '../../hooks/use-toast.js'
 import { usersApi } from '../../api/users.api.js'
@@ -169,7 +170,20 @@ export default function ContactList() {
       ) : error ? (
         <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-md">{error.message}</p>
       ) : contacts.length === 0 ? (
-        <p className="text-sm text-gray-400 py-4">No contacts found.</p>
+        statusFilter || ownerFilter ? (
+          <EmptyState
+            icon={<Users size={28} />}
+            heading="No contacts found"
+            description="No contacts match the selected filters. Try adjusting or clearing your filters."
+          />
+        ) : (
+          <EmptyState
+            icon={<Users size={28} />}
+            heading="No contacts yet"
+            description="Your CRM is ready for people — add your first contact to get started."
+            action={{ label: '+ Add your first contact', onClick: () => setSheetOpen(true) }}
+          />
+        )
       ) : (
         <Card className="p-0 overflow-hidden">
           <BulkActionBar selectedCount={selectedCount} onClearSelection={clearSelection}>

--- a/frontend/src/pages/deals/Pipeline.jsx
+++ b/frontend/src/pages/deals/Pipeline.jsx
@@ -1,10 +1,12 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
+import { TrendingUp } from 'lucide-react'
 import { dealsApi } from '../../api/deals.api.js'
 import DealForm from './DealForm.jsx'
 import { Button } from '../../components/ui/button.jsx'
 import { Skeleton } from '../../components/ui/skeleton.jsx'
+import { EmptyState } from '../../components/EmptyState.jsx'
 import {
   Sheet,
   SheetContent,
@@ -76,6 +78,8 @@ export default function Pipeline() {
     e.dataTransfer.dropEffect = 'move'
   }
 
+  const totalDeals = board.reduce((sum, col) => sum + col.deals.length, 0)
+
   return (
     <div>
       <div className="flex items-center justify-between mb-5">
@@ -83,6 +87,14 @@ export default function Pipeline() {
         <Button onClick={() => setSheetOpen(true)}>+ New Deal</Button>
       </div>
 
+      {totalDeals === 0 ? (
+        <EmptyState
+          icon={<TrendingUp size={28} />}
+          heading="No deals in your pipeline"
+          description="Start tracking your sales — add your first deal to the pipeline."
+          action={{ label: '+ Add your first deal', onClick: () => setSheetOpen(true) }}
+        />
+      ) : (
       <div className="flex gap-4 overflow-x-auto pb-4 items-start">
         {board.map((col) => {
           const style = STAGE_STYLES[col.stage] ?? { header: 'text-gray-600', border: 'border-gray-200 bg-gray-50' }
@@ -124,6 +136,7 @@ export default function Pipeline() {
           )
         })}
       </div>
+      )}
 
       <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
         <SheetContent className="sm:max-w-lg overflow-y-auto">


### PR DESCRIPTION
Replace plain empty text with an EmptyState component (icon + heading + description + CTA button) for all list views: Contacts, Accounts, Deals (Pipeline), and Tasks.

Closes #12

Generated with [Claude Code](https://claude.ai/code)