### PR TITLE
feat: confirmation dialogs for destructive actions (issue #13)

### DIFF
--- a/frontend/src/components/ActivityTimeline.jsx
+++ b/frontend/src/components/ActivityTimeline.jsx
@@ -1,7 +1,16 @@
+import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { activitiesApi } from '../api/activities.api.js'
 import { Button } from './ui/button.jsx'
 import { Skeleton } from './ui/skeleton.jsx'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './ui/dialog.jsx'
 
 const TYPE_BORDER = {
   Call:    'border-l-blue-500',
@@ -28,6 +37,7 @@ function formatDate(iso) {
 
 export default function ActivityTimeline({ contactId, dealId, accountId, queryKey }) {
   const queryClient = useQueryClient()
+  const [deleteTarget, setDeleteTarget] = useState(null)
 
   const params = {}
   if (contactId) params.contactId = contactId
@@ -46,7 +56,10 @@ export default function ActivityTimeline({ contactId, dealId, accountId, queryKe
 
   const deleteMutation = useMutation({
     mutationFn: (id) => activitiesApi.delete(id),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: [queryKey ?? 'activities', params] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [queryKey ?? 'activities', params] })
+      setDeleteTarget(null)
+    },
   })
 
   if (isLoading) {
@@ -64,52 +77,78 @@ export default function ActivityTimeline({ contactId, dealId, accountId, queryKe
   }
 
   return (
-    <div className="flex flex-col gap-3">
-      {activities.map((a) => (
-        <div
-          key={a.activityId}
-          className={`flex gap-3 p-3 rounded-lg border-l-[3px] bg-gray-50 ${TYPE_BORDER[a.type] ?? 'border-l-gray-300'}`}
-        >
-          <div className="text-base w-6 flex-shrink-0 pt-px">{TYPE_ICONS[a.type] ?? '•'}</div>
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 flex-wrap mb-1">
-              <span className="text-[11px] font-bold uppercase tracking-wider text-gray-500">
-                {a.type}
-              </span>
-              {a.type === 'Task' && (
-                a.completedAt
-                  ? <span className="text-xs text-emerald-600">Completed {formatDate(a.completedAt)}</span>
-                  : (
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      className="h-6 text-xs px-2"
-                      disabled={completeMutation.isPending}
-                      onClick={() => completeMutation.mutate(a.activityId)}
-                    >
-                      Mark complete
-                    </Button>
-                  )
+    <>
+      <div className="flex flex-col gap-3">
+        {activities.map((a) => (
+          <div
+            key={a.activityId}
+            className={`flex gap-3 p-3 rounded-lg border-l-[3px] bg-gray-50 ${TYPE_BORDER[a.type] ?? 'border-l-gray-300'}`}
+          >
+            <div className="text-base w-6 flex-shrink-0 pt-px">{TYPE_ICONS[a.type] ?? '•'}</div>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 flex-wrap mb-1">
+                <span className="text-[11px] font-bold uppercase tracking-wider text-gray-500">
+                  {a.type}
+                </span>
+                {a.type === 'Task' && (
+                  a.completedAt
+                    ? <span className="text-xs text-emerald-600">Completed {formatDate(a.completedAt)}</span>
+                    : (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-6 text-xs px-2"
+                        disabled={completeMutation.isPending}
+                        onClick={() => completeMutation.mutate(a.activityId)}
+                      >
+                        Mark complete
+                      </Button>
+                    )
+                )}
+                <span className="ml-auto text-xs text-gray-400">{formatDate(a.createdAt)}</span>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-6 w-6 p-0 text-gray-400 hover:text-red-500 hover:bg-red-50"
+                  onClick={() => setDeleteTarget(a)}
+                >
+                  ×
+                </Button>
+              </div>
+              <p className="text-sm font-medium text-gray-900 m-0">{a.subject}</p>
+              {a.notes && <p className="text-sm text-gray-500 mt-0.5">{a.notes}</p>}
+              {a.scheduledAt && !a.completedAt && (
+                <p className="text-xs text-amber-600 mt-0.5">Scheduled: {formatDate(a.scheduledAt)}</p>
               )}
-              <span className="ml-auto text-xs text-gray-400">{formatDate(a.createdAt)}</span>
-              <Button
-                size="sm"
-                variant="ghost"
-                className="h-6 w-6 p-0 text-gray-400 hover:text-red-500 hover:bg-red-50"
-                disabled={deleteMutation.isPending}
-                onClick={() => deleteMutation.mutate(a.activityId)}
-              >
-                ×
-              </Button>
             </div>
-            <p className="text-sm font-medium text-gray-900 m-0">{a.subject}</p>
-            {a.notes && <p className="text-sm text-gray-500 mt-0.5">{a.notes}</p>}
-            {a.scheduledAt && !a.completedAt && (
-              <p className="text-xs text-amber-600 mt-0.5">Scheduled: {formatDate(a.scheduledAt)}</p>
-            )}
           </div>
-        </div>
-      ))}
-    </div>
+        ))}
+      </div>
+
+      <Dialog open={!!deleteTarget} onOpenChange={(open) => { if (!open) setDeleteTarget(null) }}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Delete Activity</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete{' '}
+              <strong>"{deleteTarget?.subject}"</strong>?
+              This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteTarget(null)} disabled={deleteMutation.isPending}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={deleteMutation.isPending}
+              onClick={() => deleteMutation.mutate(deleteTarget.activityId)}
+            >
+              {deleteMutation.isPending ? 'Deleting…' : 'Delete'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }

--- a/frontend/src/pages/accounts/AccountDetail.jsx
+++ b/frontend/src/pages/accounts/AccountDetail.jsx
@@ -20,7 +20,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from '../../components/ui/dialog.jsx'
 import {
   Sheet,
@@ -43,6 +42,7 @@ export default function AccountDetail() {
   const queryClient = useQueryClient()
   const [editOpen, setEditOpen] = useState(false)
   const [addContactOpen, setAddContactOpen] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
 
   const { data: account, isLoading, error } = useQuery({
     queryKey: ['account', id],
@@ -116,31 +116,7 @@ export default function AccountDetail() {
         <h1 className="text-2xl font-bold text-gray-900">{account.name}</h1>
         <div className="flex gap-2">
           <Button variant="outline" onClick={() => setEditOpen(true)}>Edit</Button>
-          <Dialog>
-            <DialogTrigger asChild>
-              <Button variant="destructive">Delete</Button>
-            </DialogTrigger>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>Delete account?</DialogTitle>
-                <DialogDescription>
-                  This will permanently delete <strong>{account.name}</strong> and all associated data. This action cannot be undone.
-                </DialogDescription>
-              </DialogHeader>
-              <DialogFooter>
-                <Button variant="outline" onClick={(e) => e.currentTarget.closest('[role=dialog]')?.querySelector('[aria-label=Close]')?.click()}>
-                  Cancel
-                </Button>
-                <Button
-                  variant="destructive"
-                  disabled={deleteMutation.isPending}
-                  onClick={() => deleteMutation.mutate()}
-                >
-                  {deleteMutation.isPending ? 'Deleting…' : 'Delete'}
-                </Button>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
+          <Button variant="destructive" onClick={() => setDeleteOpen(true)}>Delete</Button>
         </div>
       </div>
 
@@ -244,6 +220,30 @@ export default function AccountDetail() {
           </div>
         </SheetContent>
       </Sheet>
+
+      {/* Delete Account Confirmation Dialog */}
+      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Delete account?</DialogTitle>
+            <DialogDescription>
+              This will permanently delete <strong>{account.name}</strong> and all associated data. This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteOpen(false)} disabled={deleteMutation.isPending}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={deleteMutation.isPending}
+              onClick={() => deleteMutation.mutate()}
+            >
+              {deleteMutation.isPending ? 'Deleting…' : 'Delete'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/frontend/src/pages/contacts/ContactDetail.jsx
+++ b/frontend/src/pages/contacts/ContactDetail.jsx
@@ -19,7 +19,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from '../../components/ui/dialog.jsx'
 import {
   Sheet,
@@ -48,6 +47,7 @@ export default function ContactDetail() {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [editOpen, setEditOpen] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
 
   const { data: contact, isLoading, error } = useQuery({
     queryKey: ['contact', id],
@@ -135,31 +135,7 @@ export default function ContactDetail() {
         <h1 className="text-2xl font-bold text-gray-900">{contact.firstName} {contact.lastName}</h1>
         <div className="flex gap-2">
           <Button variant="outline" onClick={() => setEditOpen(true)}>Edit</Button>
-          <Dialog>
-            <DialogTrigger asChild>
-              <Button variant="destructive">Delete</Button>
-            </DialogTrigger>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>Delete contact?</DialogTitle>
-                <DialogDescription>
-                  This will permanently delete {contact.firstName} {contact.lastName} and all associated data. This action cannot be undone.
-                </DialogDescription>
-              </DialogHeader>
-              <DialogFooter>
-                <Button variant="outline" onClick={(e) => e.currentTarget.closest('[role=dialog]')?.querySelector('[aria-label=Close]')?.click()}>
-                  Cancel
-                </Button>
-                <Button
-                  variant="destructive"
-                  disabled={deleteMutation.isPending}
-                  onClick={() => deleteMutation.mutate()}
-                >
-                  {deleteMutation.isPending ? 'Deleting…' : 'Delete'}
-                </Button>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
+          <Button variant="destructive" onClick={() => setDeleteOpen(true)}>Delete</Button>
         </div>
       </div>
 
@@ -253,6 +229,30 @@ export default function ContactDetail() {
           </div>
         </SheetContent>
       </Sheet>
+
+      {/* Delete Contact Confirmation Dialog */}
+      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Delete contact?</DialogTitle>
+            <DialogDescription>
+              This will permanently delete <strong>{contact.firstName} {contact.lastName}</strong> and all associated data. This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteOpen(false)} disabled={deleteMutation.isPending}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={deleteMutation.isPending}
+              onClick={() => deleteMutation.mutate()}
+            >
+              {deleteMutation.isPending ? 'Deleting…' : 'Delete'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/frontend/src/pages/deals/DealDetail.jsx
+++ b/frontend/src/pages/deals/DealDetail.jsx
@@ -21,7 +21,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from '../../components/ui/dialog.jsx'
 import {
   Select,
@@ -48,6 +47,8 @@ export default function DealDetail() {
   const [contactId, setContactId] = useState('')
   const [contactRole, setContactRole] = useState('Influencer')
   const [editOpen, setEditOpen] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [removeTarget, setRemoveTarget] = useState(null)
 
   const { data: deal, isLoading, error } = useQuery({
     queryKey: ['deal', id],
@@ -98,6 +99,7 @@ export default function DealDetail() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['deal', id] })
       toast({ variant: 'success', title: 'Contact removed' })
+      setRemoveTarget(null)
     },
     onError: (err) => toast({ variant: 'destructive', title: 'Failed to remove contact', description: err.message }),
   })
@@ -167,27 +169,7 @@ export default function DealDetail() {
         </div>
         <div className="flex gap-2">
           <Button variant="outline" onClick={() => setEditOpen(true)}>Edit</Button>
-          <Dialog>
-            <DialogTrigger asChild>
-              <Button variant="destructive">Delete</Button>
-            </DialogTrigger>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>Delete deal?</DialogTitle>
-                <DialogDescription>
-                  This will permanently delete <strong>{deal.title}</strong>. This action cannot be undone.
-                </DialogDescription>
-              </DialogHeader>
-              <DialogFooter>
-                <Button variant="outline" onClick={(e) => e.currentTarget.closest('[role=dialog]')?.querySelector('[aria-label=Close]')?.click()}>
-                  Cancel
-                </Button>
-                <Button variant="destructive" onClick={() => deleteDeal.mutate()} disabled={deleteDeal.isPending}>
-                  {deleteDeal.isPending ? 'Deleting…' : 'Delete'}
-                </Button>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
+          <Button variant="destructive" onClick={() => setDeleteOpen(true)}>Delete</Button>
         </div>
       </div>
 
@@ -253,7 +235,7 @@ export default function DealDetail() {
                       </TableCell>
                       <TableCell>{dc.role}</TableCell>
                       <TableCell>
-                        <Button size="sm" variant="destructive" onClick={() => removeContact.mutate(dc.contactId)}>
+                        <Button size="sm" variant="destructive" onClick={() => setRemoveTarget(dc)}>
                           Remove
                         </Button>
                       </TableCell>
@@ -321,6 +303,57 @@ export default function DealDetail() {
           </div>
         </SheetContent>
       </Sheet>
+
+      {/* Delete Deal Confirmation Dialog */}
+      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Delete deal?</DialogTitle>
+            <DialogDescription>
+              This will permanently delete <strong>{deal.title}</strong>. This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteOpen(false)} disabled={deleteDeal.isPending}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={() => deleteDeal.mutate()} disabled={deleteDeal.isPending}>
+              {deleteDeal.isPending ? 'Deleting…' : 'Delete'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Remove Deal-Contact Confirmation Dialog */}
+      <Dialog open={!!removeTarget} onOpenChange={(open) => { if (!open) setRemoveTarget(null) }}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Remove contact?</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to remove{' '}
+              <strong>
+                {(() => {
+                  const c = allContacts.find((c) => c.contactId === removeTarget?.contactId)
+                  return c ? `${c.firstName} ${c.lastName}` : 'this contact'
+                })()}
+              </strong>{' '}
+              from this deal? This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRemoveTarget(null)} disabled={removeContact.isPending}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={removeContact.isPending}
+              onClick={() => removeContact.mutate(removeTarget.contactId)}
+            >
+              {removeContact.isPending ? 'Removing…' : 'Remove'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }


### PR DESCRIPTION
Adds confirmation dialogs for all destructive actions as required by issue #13.

- ActivityTimeline: delete activity now requires confirmation
- DealDetail: remove deal-contact association now requires confirmation
- ContactDetail, AccountDetail, DealDetail: delete buttons converted to controlled dialog state (fixes fragile DOM-traversal Cancel button)

Closes #13

Generated with [Claude Code](https://claude.ai/code)