### PR TITLE
feat: Admin section — user management UI (#16)

### DIFF
--- a/ApiGateway/src/ApiGateway/Program.cs
+++ b/ApiGateway/src/ApiGateway/Program.cs
@@ -26,7 +26,10 @@ builder.Services
       };
     });
 
-builder.Services.AddAuthorization();
+builder.Services.AddAuthorization(options =>
+{
+  options.AddPolicy("admin", policy => policy.RequireRole("Admin"));
+});
 
 builder.Services.AddReverseProxy()
     .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"));

--- a/ApiGateway/src/ApiGateway/appsettings.json
+++ b/ApiGateway/src/ApiGateway/appsettings.json
@@ -55,6 +55,12 @@
         "Transforms": [{ "PathRemovePrefix": "/activities" }],
         "AuthorizationPolicy": "default"
       },
+      "admin-route": {
+        "ClusterId": "users-cluster",
+        "Match": { "Path": "/admin/{**catch-all}" },
+        "Transforms": [{ "PathRemovePrefix": "/admin" }],
+        "AuthorizationPolicy": "admin"
+      },
       "reports-route": {
         "ClusterId": "reports-cluster",
         "Match": { "Path": "/reports/{**catch-all}" },

--- a/UserManagementService/src/UserManagementService.Tests/Controllers/AdminControllerTests.cs
+++ b/UserManagementService/src/UserManagementService.Tests/Controllers/AdminControllerTests.cs
@@ -1,0 +1,133 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using SharedLibrary.Enums;
+using UserManagementService.Controllers;
+using UserManagementService.Models.DTOs;
+using UserManagementService.Services;
+
+namespace UserManagementService.Tests.Controllers;
+
+public class AdminControllerTests
+{
+  private readonly Mock<IUserProfileService> _serviceMock = new();
+  private readonly Mock<ILogger<AdminController>> _loggerMock = new();
+  private readonly AdminController _sut;
+
+  public AdminControllerTests()
+  {
+    _sut = new AdminController(_serviceMock.Object, _loggerMock.Object);
+  }
+
+  // ── GetAllUsers ───────────────────────────────────────────────────────────
+
+  [Fact]
+  public async Task GetAllUsers_ReturnsOk_WithUserList()
+  {
+    _serviceMock.Setup(s => s.GetAllUsersAsync())
+      .ReturnsAsync(ServiceResult.Success(new List<AdminUserResponse>()));
+
+    var result = await _sut.GetAllUsers();
+
+    var obj = result.Should().BeOfType<ObjectResult>().Subject;
+    obj.StatusCode.Should().Be(200);
+  }
+
+  [Fact]
+  public async Task GetAllUsers_Returns500_OnException()
+  {
+    _serviceMock.Setup(s => s.GetAllUsersAsync()).ThrowsAsync(new Exception());
+
+    var result = await _sut.GetAllUsers();
+
+    var obj = result.Should().BeOfType<ObjectResult>().Subject;
+    obj.StatusCode.Should().Be(500);
+  }
+
+  // ── UpdateUserRole ────────────────────────────────────────────────────────
+
+  [Fact]
+  public async Task UpdateUserRole_ReturnsOk_WhenSuccessful()
+  {
+    var userId = Guid.NewGuid();
+    var request = new UpdateUserRoleRequest { Role = UserRole.Admin };
+    _serviceMock.Setup(s => s.UpdateUserRoleAsync(userId, UserRole.Admin))
+      .ReturnsAsync(ServiceResult.Success(new AdminUserResponse { UserId = userId, Role = UserRole.Admin }));
+
+    var result = await _sut.UpdateUserRole(userId, request);
+
+    var obj = result.Should().BeOfType<ObjectResult>().Subject;
+    obj.StatusCode.Should().Be(200);
+  }
+
+  [Fact]
+  public async Task UpdateUserRole_Returns404_WhenNotFound()
+  {
+    var userId = Guid.NewGuid();
+    var request = new UpdateUserRoleRequest { Role = UserRole.Admin };
+    _serviceMock.Setup(s => s.UpdateUserRoleAsync(userId, UserRole.Admin))
+      .ReturnsAsync(ServiceResult.Failure("User profile not found.", 404));
+
+    var result = await _sut.UpdateUserRole(userId, request);
+
+    var obj = result.Should().BeOfType<ObjectResult>().Subject;
+    obj.StatusCode.Should().Be(404);
+  }
+
+  [Fact]
+  public async Task UpdateUserRole_Returns500_OnException()
+  {
+    var userId = Guid.NewGuid();
+    var request = new UpdateUserRoleRequest { Role = UserRole.Admin };
+    _serviceMock.Setup(s => s.UpdateUserRoleAsync(userId, UserRole.Admin)).ThrowsAsync(new Exception());
+
+    var result = await _sut.UpdateUserRole(userId, request);
+
+    var obj = result.Should().BeOfType<ObjectResult>().Subject;
+    obj.StatusCode.Should().Be(500);
+  }
+
+  // ── SetUserActive ─────────────────────────────────────────────────────────
+
+  [Fact]
+  public async Task SetUserActive_ReturnsOk_WhenSuccessful()
+  {
+    var userId = Guid.NewGuid();
+    var request = new SetUserActiveRequest { IsActive = false };
+    _serviceMock.Setup(s => s.SetUserActiveAsync(userId, false))
+      .ReturnsAsync(ServiceResult.Success(new AdminUserResponse { UserId = userId, IsActive = false }));
+
+    var result = await _sut.SetUserActive(userId, request);
+
+    var obj = result.Should().BeOfType<ObjectResult>().Subject;
+    obj.StatusCode.Should().Be(200);
+  }
+
+  [Fact]
+  public async Task SetUserActive_Returns404_WhenNotFound()
+  {
+    var userId = Guid.NewGuid();
+    var request = new SetUserActiveRequest { IsActive = false };
+    _serviceMock.Setup(s => s.SetUserActiveAsync(userId, false))
+      .ReturnsAsync(ServiceResult.Failure("User profile not found.", 404));
+
+    var result = await _sut.SetUserActive(userId, request);
+
+    var obj = result.Should().BeOfType<ObjectResult>().Subject;
+    obj.StatusCode.Should().Be(404);
+  }
+
+  [Fact]
+  public async Task SetUserActive_Returns500_OnException()
+  {
+    var userId = Guid.NewGuid();
+    var request = new SetUserActiveRequest { IsActive = false };
+    _serviceMock.Setup(s => s.SetUserActiveAsync(userId, false)).ThrowsAsync(new Exception());
+
+    var result = await _sut.SetUserActive(userId, request);
+
+    var obj = result.Should().BeOfType<ObjectResult>().Subject;
+    obj.StatusCode.Should().Be(500);
+  }
+}

--- a/UserManagementService/src/UserManagementService.Tests/Services/AdminServiceTests.cs
+++ b/UserManagementService/src/UserManagementService.Tests/Services/AdminServiceTests.cs
@@ -1,0 +1,104 @@
+using FluentAssertions;
+using Moq;
+using SharedLibrary.Enums;
+using UserManagementService.Models;
+using UserManagementService.Models.DTOs;
+using UserManagementService.Repository;
+using UserManagementService.Services;
+
+namespace UserManagementService.Tests.Services;
+
+public class AdminServiceTests
+{
+  private readonly Mock<IUserProfileRepository> _mockRepository;
+  private readonly UserProfileService _service;
+
+  public AdminServiceTests()
+  {
+    _mockRepository = new Mock<IUserProfileRepository>();
+    _service = new UserProfileService(_mockRepository.Object);
+  }
+
+  // ── GetAllUsersAsync ──────────────────────────────────────────────────────
+
+  [Fact]
+  public async Task GetAllUsersAsync_ReturnsAllUsers()
+  {
+    var profiles = new List<UserProfile>
+    {
+      new() { UserId = Guid.NewGuid(), Email = "a@example.com", DisplayName = "Alice", Role = UserRole.Admin, IsActive = true },
+      new() { UserId = Guid.NewGuid(), Email = "b@example.com", DisplayName = "Bob", Role = UserRole.Member, IsActive = false },
+    };
+    _mockRepository.Setup(r => r.GetAllAsync()).ReturnsAsync(profiles);
+
+    var result = await _service.GetAllUsersAsync();
+
+    result.IsSuccess.Should().BeTrue();
+    result.StatusCode.Should().Be(200);
+    var users = result.Data as List<AdminUserResponse>;
+    users.Should().NotBeNull();
+    users!.Count.Should().Be(2);
+    users[0].Email.Should().Be("a@example.com");
+    users[1].IsActive.Should().BeFalse();
+  }
+
+  // ── UpdateUserRoleAsync ───────────────────────────────────────────────────
+
+  [Fact]
+  public async Task UpdateUserRoleAsync_WhenUserExists_UpdatesRole()
+  {
+    var userId = Guid.NewGuid();
+    var profile = new UserProfile { UserId = userId, Email = "user@example.com", Role = UserRole.Member, IsActive = true };
+    _mockRepository.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync(profile);
+    _mockRepository.Setup(r => r.UpdateAsync(It.IsAny<UserProfile>())).Returns(Task.CompletedTask);
+
+    var result = await _service.UpdateUserRoleAsync(userId, UserRole.Admin);
+
+    result.IsSuccess.Should().BeTrue();
+    result.StatusCode.Should().Be(200);
+    var response = result.Data as AdminUserResponse;
+    response!.Role.Should().Be(UserRole.Admin);
+  }
+
+  [Fact]
+  public async Task UpdateUserRoleAsync_WhenUserNotFound_ReturnsFailure()
+  {
+    var userId = Guid.NewGuid();
+    _mockRepository.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync((UserProfile?)null);
+
+    var result = await _service.UpdateUserRoleAsync(userId, UserRole.Admin);
+
+    result.IsSuccess.Should().BeFalse();
+    result.StatusCode.Should().Be(404);
+  }
+
+  // ── SetUserActiveAsync ────────────────────────────────────────────────────
+
+  [Fact]
+  public async Task SetUserActiveAsync_WhenUserExists_UpdatesActiveStatus()
+  {
+    var userId = Guid.NewGuid();
+    var profile = new UserProfile { UserId = userId, Email = "user@example.com", Role = UserRole.Member, IsActive = true };
+    _mockRepository.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync(profile);
+    _mockRepository.Setup(r => r.UpdateAsync(It.IsAny<UserProfile>())).Returns(Task.CompletedTask);
+
+    var result = await _service.SetUserActiveAsync(userId, false);
+
+    result.IsSuccess.Should().BeTrue();
+    result.StatusCode.Should().Be(200);
+    var response = result.Data as AdminUserResponse;
+    response!.IsActive.Should().BeFalse();
+  }
+
+  [Fact]
+  public async Task SetUserActiveAsync_WhenUserNotFound_ReturnsFailure()
+  {
+    var userId = Guid.NewGuid();
+    _mockRepository.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync((UserProfile?)null);
+
+    var result = await _service.SetUserActiveAsync(userId, false);
+
+    result.IsSuccess.Should().BeFalse();
+    result.StatusCode.Should().Be(404);
+  }
+}

--- a/UserManagementService/src/UserManagementService/Controllers/AdminController.cs
+++ b/UserManagementService/src/UserManagementService/Controllers/AdminController.cs
@@ -1,0 +1,64 @@
+using Microsoft.AspNetCore.Mvc;
+using UserManagementService.Models.DTOs;
+using UserManagementService.Services;
+
+namespace UserManagementService.Controllers;
+
+[ApiController]
+[Route("api/admin")]
+public class AdminController : ControllerBase
+{
+  private readonly IUserProfileService _userProfileService;
+  private readonly ILogger<AdminController> _logger;
+
+  public AdminController(IUserProfileService userProfileService, ILogger<AdminController> logger)
+  {
+    _userProfileService = userProfileService;
+    _logger = logger;
+  }
+
+  [HttpGet("users")]
+  public async Task<IActionResult> GetAllUsers()
+  {
+    try
+    {
+      var result = await _userProfileService.GetAllUsersAsync();
+      return StatusCode(result.StatusCode, result.Data ?? result.Message);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Error retrieving all users");
+      return StatusCode(500, "An error occurred while retrieving users.");
+    }
+  }
+
+  [HttpPut("users/{userId:guid}/role")]
+  public async Task<IActionResult> UpdateUserRole(Guid userId, [FromBody] UpdateUserRoleRequest request)
+  {
+    try
+    {
+      var result = await _userProfileService.UpdateUserRoleAsync(userId, request.Role);
+      return StatusCode(result.StatusCode, result.Data ?? result.Message);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Error updating role for user {UserId}", userId);
+      return StatusCode(500, "An error occurred while updating the user role.");
+    }
+  }
+
+  [HttpPut("users/{userId:guid}/active")]
+  public async Task<IActionResult> SetUserActive(Guid userId, [FromBody] SetUserActiveRequest request)
+  {
+    try
+    {
+      var result = await _userProfileService.SetUserActiveAsync(userId, request.IsActive);
+      return StatusCode(result.StatusCode, result.Data ?? result.Message);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Error updating active status for user {UserId}", userId);
+      return StatusCode(500, "An error occurred while updating the user active status.");
+    }
+  }
+}

--- a/UserManagementService/src/UserManagementService/Models/DTOs/AdminUserResponse.cs
+++ b/UserManagementService/src/UserManagementService/Models/DTOs/AdminUserResponse.cs
@@ -1,0 +1,13 @@
+using SharedLibrary.Enums;
+
+namespace UserManagementService.Models.DTOs;
+
+public class AdminUserResponse
+{
+  public Guid UserId { get; set; }
+  public string Email { get; set; } = string.Empty;
+  public string DisplayName { get; set; } = string.Empty;
+  public UserRole Role { get; set; }
+  public bool IsActive { get; set; }
+  public DateTime CreatedAt { get; set; }
+}

--- a/UserManagementService/src/UserManagementService/Models/DTOs/SetUserActiveRequest.cs
+++ b/UserManagementService/src/UserManagementService/Models/DTOs/SetUserActiveRequest.cs
@@ -1,0 +1,6 @@
+namespace UserManagementService.Models.DTOs;
+
+public class SetUserActiveRequest
+{
+  public bool IsActive { get; set; }
+}

--- a/UserManagementService/src/UserManagementService/Models/DTOs/UpdateUserRoleRequest.cs
+++ b/UserManagementService/src/UserManagementService/Models/DTOs/UpdateUserRoleRequest.cs
@@ -1,0 +1,8 @@
+using SharedLibrary.Enums;
+
+namespace UserManagementService.Models.DTOs;
+
+public class UpdateUserRoleRequest
+{
+  public UserRole Role { get; set; }
+}

--- a/UserManagementService/src/UserManagementService/Models/UserProfile.cs
+++ b/UserManagementService/src/UserManagementService/Models/UserProfile.cs
@@ -18,4 +18,6 @@ public class UserProfile
   public string DisplayName { get; set; } = string.Empty;
 
   public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+  public bool IsActive { get; set; } = true;
 }

--- a/UserManagementService/src/UserManagementService/Services/IUserProfileService.cs
+++ b/UserManagementService/src/UserManagementService/Services/IUserProfileService.cs
@@ -1,4 +1,5 @@
 using SharedLibrary.DTOs;
+using SharedLibrary.Enums;
 
 namespace UserManagementService.Services;
 
@@ -8,4 +9,7 @@ public interface IUserProfileService
   Task<ServiceResult> GetUserProfileAsync(Guid userId);
   Task<ServiceResult> GetUserRoleAsync(Guid userId);
   Task<ServiceResult> GetTeamAsync();
+  Task<ServiceResult> GetAllUsersAsync();
+  Task<ServiceResult> UpdateUserRoleAsync(Guid userId, UserRole role);
+  Task<ServiceResult> SetUserActiveAsync(Guid userId, bool isActive);
 }

--- a/UserManagementService/src/UserManagementService/Services/UserProfileService.cs
+++ b/UserManagementService/src/UserManagementService/Services/UserProfileService.cs
@@ -3,7 +3,6 @@ using SharedLibrary.Enums;
 using UserManagementService.Models;
 using UserManagementService.Models.DTOs;
 using UserManagementService.Repository;
-using Microsoft.EntityFrameworkCore;
 
 namespace UserManagementService.Services;
 
@@ -73,5 +72,61 @@ public class UserProfileService : IUserProfileService
     }).ToList();
 
     return ServiceResult.Success(team);
+  }
+
+  public async Task<ServiceResult> GetAllUsersAsync()
+  {
+    var profiles = await _repository.GetAllAsync();
+    var users = profiles.Select(p => new AdminUserResponse
+    {
+      UserId = p.UserId,
+      Email = p.Email,
+      DisplayName = p.DisplayName,
+      Role = p.Role,
+      IsActive = p.IsActive,
+      CreatedAt = p.CreatedAt
+    }).ToList();
+
+    return ServiceResult.Success(users);
+  }
+
+  public async Task<ServiceResult> UpdateUserRoleAsync(Guid userId, UserRole role)
+  {
+    var profile = await _repository.GetByIdAsync(userId);
+    if (profile == null)
+      return ServiceResult.Failure("User profile not found.", 404);
+
+    profile.Role = role;
+    await _repository.UpdateAsync(profile);
+
+    return ServiceResult.Success(new AdminUserResponse
+    {
+      UserId = profile.UserId,
+      Email = profile.Email,
+      DisplayName = profile.DisplayName,
+      Role = profile.Role,
+      IsActive = profile.IsActive,
+      CreatedAt = profile.CreatedAt
+    });
+  }
+
+  public async Task<ServiceResult> SetUserActiveAsync(Guid userId, bool isActive)
+  {
+    var profile = await _repository.GetByIdAsync(userId);
+    if (profile == null)
+      return ServiceResult.Failure("User profile not found.", 404);
+
+    profile.IsActive = isActive;
+    await _repository.UpdateAsync(profile);
+
+    return ServiceResult.Success(new AdminUserResponse
+    {
+      UserId = profile.UserId,
+      Email = profile.Email,
+      DisplayName = profile.DisplayName,
+      Role = profile.Role,
+      IsActive = profile.IsActive,
+      CreatedAt = profile.CreatedAt
+    });
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { AuthProvider } from './context/AuthContext.jsx'
 import ProtectedRoute from './components/ProtectedRoute.jsx'
+import AdminRoute from './components/AdminRoute.jsx'
 import Layout from './components/Layout.jsx'
 import Login from './pages/auth/Login.jsx'
 import Register from './pages/auth/Register.jsx'
@@ -16,6 +17,7 @@ import DealDetail from './pages/deals/DealDetail.jsx'
 import DealForm from './pages/deals/DealForm.jsx'
 import TaskList from './pages/activities/TaskList.jsx'
 import Dashboard from './pages/dashboard/Dashboard.jsx'
+import AdminUserList from './pages/admin/AdminUserList.jsx'
 
 export default function App() {
   return (
@@ -42,6 +44,9 @@ export default function App() {
               <Route path="/activities/tasks" element={<TaskList />} />
               <Route path="/dashboard" element={<Dashboard />} />
               <Route path="/profile" element={<Profile />} />
+              <Route element={<AdminRoute />}>
+                <Route path="/admin/users" element={<AdminUserList />} />
+              </Route>
             </Route>
           </Route>
           <Route path="*" element={<Navigate to="/contacts" replace />} />

--- a/frontend/src/api/users.api.js
+++ b/frontend/src/api/users.api.js
@@ -1,8 +1,23 @@
 import { apiFetch } from './apiClient.js'
 
 const BASE = '/users/api/users'
+const ADMIN_BASE = '/admin/api/admin'
 
 export const usersApi = {
   getProfile: (userId) => apiFetch(`${BASE}/${userId}`),
   getTeam: () => apiFetch(`${BASE}/team`),
+}
+
+export const adminApi = {
+  listUsers: () => apiFetch(`${ADMIN_BASE}/users`),
+  updateRole: (userId, role) =>
+    apiFetch(`${ADMIN_BASE}/users/${userId}/role`, {
+      method: 'PUT',
+      body: JSON.stringify({ role }),
+    }),
+  setActive: (userId, isActive) =>
+    apiFetch(`${ADMIN_BASE}/users/${userId}/active`, {
+      method: 'PUT',
+      body: JSON.stringify({ isActive }),
+    }),
 }

--- a/frontend/src/components/AdminRoute.jsx
+++ b/frontend/src/components/AdminRoute.jsx
@@ -1,0 +1,7 @@
+import { Navigate, Outlet } from 'react-router-dom'
+import { useAuth } from '../context/AuthContext.jsx'
+
+export default function AdminRoute() {
+  const { user } = useAuth()
+  return user?.role === 'Admin' ? <Outlet /> : <Navigate to="/contacts" replace />
+}

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
 import { NavLink, Outlet } from 'react-router-dom'
-import { Users, Building2, BarChart3, CheckSquare, LayoutDashboard, ChevronLeft, ChevronRight } from 'lucide-react'
+import { Users, Building2, BarChart3, CheckSquare, LayoutDashboard, ChevronLeft, ChevronRight, ShieldCheck } from 'lucide-react'
 import TopBar from './TopBar.jsx'
+import { useAuth } from '../context/AuthContext.jsx'
 import { cn } from '../lib/utils'
 
 const navGroups = [
@@ -27,8 +28,17 @@ const navGroups = [
   },
 ]
 
+const adminNavGroup = {
+  label: 'Admin',
+  items: [
+    { to: '/admin/users', label: 'Users', Icon: ShieldCheck },
+  ],
+}
+
 export default function Layout() {
   const [collapsed, setCollapsed] = useState(false)
+  const { user } = useAuth()
+  const isAdmin = user?.role === 'Admin'
 
   return (
     <div className="flex flex-col min-h-screen">
@@ -63,7 +73,7 @@ export default function Layout() {
 
           {/* Nav */}
           <nav className="flex-1 overflow-y-auto py-3">
-            {navGroups.map(group => (
+            {[...navGroups, ...(isAdmin ? [adminNavGroup] : [])].map(group => (
               <div key={group.label} className="mb-1">
                 {!collapsed && (
                   <div className="px-4 pt-2 pb-1 text-[11px] font-semibold uppercase tracking-widest text-sidebar-muted select-none">

--- a/frontend/src/pages/admin/AdminUserList.jsx
+++ b/frontend/src/pages/admin/AdminUserList.jsx
@@ -1,0 +1,231 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { ShieldCheck, UserCheck, UserX } from 'lucide-react'
+import { adminApi } from '../../api/users.api.js'
+import { useAuth } from '../../context/AuthContext.jsx'
+import { toast } from '../../hooks/use-toast.js'
+import { Button } from '../../components/ui/button.jsx'
+import { Badge } from '../../components/ui/badge.jsx'
+import { Skeleton } from '../../components/ui/skeleton.jsx'
+import { Card } from '../../components/ui/card.jsx'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../components/ui/table.jsx'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../../components/ui/select.jsx'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '../../components/ui/dialog.jsx'
+import { EmptyState } from '../../components/EmptyState.jsx'
+
+const ROLES = ['Unassigned', 'Member', 'Admin']
+
+const ROLE_VARIANT = {
+  Admin: 'default',
+  Member: 'secondary',
+  Unassigned: 'outline',
+}
+
+export default function AdminUserList() {
+  const { user: currentUser } = useAuth()
+  const queryClient = useQueryClient()
+  const [confirmAction, setConfirmAction] = useState(null)
+
+  const { data: users = [], isLoading, error } = useQuery({
+    queryKey: ['admin', 'users'],
+    queryFn: adminApi.listUsers,
+  })
+
+  const roleMutation = useMutation({
+    mutationFn: ({ userId, role }) => adminApi.updateRole(userId, role),
+    onSuccess: (_, { role }) => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'users'] })
+      toast({ variant: 'success', title: `Role updated to ${role}` })
+    },
+    onError: (err) => toast({ variant: 'destructive', title: 'Role update failed', description: err.message }),
+  })
+
+  const activeMutation = useMutation({
+    mutationFn: ({ userId, isActive }) => adminApi.setActive(userId, isActive),
+    onSuccess: (_, { isActive }) => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'users'] })
+      toast({ variant: 'success', title: isActive ? 'Account activated' : 'Account deactivated' })
+      setConfirmAction(null)
+    },
+    onError: (err) => {
+      toast({ variant: 'destructive', title: 'Action failed', description: err.message })
+      setConfirmAction(null)
+    },
+  })
+
+  function handleRoleChange(userId, role) {
+    roleMutation.mutate({ userId, role })
+  }
+
+  function handleDeactivate(user) {
+    setConfirmAction({ type: 'deactivate', user })
+  }
+
+  function handleActivate(userId) {
+    activeMutation.mutate({ userId, isActive: true })
+  }
+
+  function confirmDeactivate() {
+    activeMutation.mutate({ userId: confirmAction.user.userId, isActive: false })
+  }
+
+  return (
+    <div>
+      <div className="flex items-center gap-3 mb-5">
+        <ShieldCheck size={24} className="text-blue-600" />
+        <h1 className="text-2xl font-bold text-gray-900">User Management</h1>
+      </div>
+
+      {isLoading ? (
+        <Card className="p-0 overflow-hidden">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                {['User', 'Email', 'Role', 'Status', 'Joined', ''].map((h, i) => (
+                  <TableHead key={i}><Skeleton className="h-4 w-16" /></TableHead>
+                ))}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {[1, 2, 3].map((i) => (
+                <TableRow key={i}>
+                  {[32, 44, 20, 16, 24, 20].map((w, j) => (
+                    <TableCell key={j}><Skeleton className={`h-4 w-${w}`} /></TableCell>
+                  ))}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Card>
+      ) : error ? (
+        <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-md">{error.message}</p>
+      ) : users.length === 0 ? (
+        <EmptyState
+          icon={<ShieldCheck size={28} />}
+          heading="No users found"
+          description="No user profiles exist yet."
+        />
+      ) : (
+        <Card className="p-0 overflow-hidden">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Display Name</TableHead>
+                <TableHead>Email</TableHead>
+                <TableHead>Role</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Joined</TableHead>
+                <TableHead className="w-32" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {users.map((u) => {
+                const isSelf = u.userId === currentUser?.userId
+                return (
+                  <TableRow key={u.userId} className={!u.isActive ? 'opacity-50' : ''}>
+                    <TableCell className="font-medium">
+                      {u.displayName || '—'}
+                      {isSelf && (
+                        <span className="ml-2 text-xs text-gray-400">(you)</span>
+                      )}
+                    </TableCell>
+                    <TableCell>{u.email}</TableCell>
+                    <TableCell>
+                      <Select
+                        value={u.role}
+                        onValueChange={(role) => handleRoleChange(u.userId, role)}
+                        disabled={isSelf || roleMutation.isPending}
+                      >
+                        <SelectTrigger className="h-7 w-32 text-xs">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {ROLES.map((r) => (
+                            <SelectItem key={r} value={r}>{r}</SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={u.isActive ? 'customer' : 'churned'}>
+                        {u.isActive ? 'Active' : 'Inactive'}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>{new Date(u.createdAt).toLocaleDateString()}</TableCell>
+                    <TableCell>
+                      <div className="flex gap-1 justify-end">
+                        {u.isActive ? (
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            className="h-7 text-xs text-red-600 hover:text-red-700 hover:bg-red-50"
+                            onClick={() => handleDeactivate(u)}
+                            disabled={isSelf || activeMutation.isPending}
+                            title="Deactivate account"
+                          >
+                            <UserX size={14} className="mr-1" />
+                            Deactivate
+                          </Button>
+                        ) : (
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            className="h-7 text-xs text-emerald-600 hover:text-emerald-700 hover:bg-emerald-50"
+                            onClick={() => handleActivate(u.userId)}
+                            disabled={activeMutation.isPending}
+                            title="Activate account"
+                          >
+                            <UserCheck size={14} className="mr-1" />
+                            Activate
+                          </Button>
+                        )}
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
+            </TableBody>
+          </Table>
+        </Card>
+      )}
+
+      <Dialog open={!!confirmAction} onOpenChange={(open) => { if (!open) setConfirmAction(null) }}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Deactivate Account</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to deactivate{' '}
+              <strong>{confirmAction?.user?.displayName || confirmAction?.user?.email}</strong>?
+              They will no longer be able to log in.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmAction(null)} disabled={activeMutation.isPending}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={confirmDeactivate}
+              disabled={activeMutation.isPending}
+            >
+              {activeMutation.isPending ? 'Deactivating…' : 'Deactivate'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}


### PR DESCRIPTION
Implements the Admin section user management UI from issue #16.

## Changes

**Backend (UserManagementService)**
- Add `IsActive` field to `UserProfile` for account deactivation
- New admin DTOs: `AdminUserResponse`, `UpdateUserRoleRequest`, `SetUserActiveRequest`
- New service methods: `GetAllUsersAsync`, `UpdateUserRoleAsync`, `SetUserActiveAsync`
- New `AdminController`: `GET /api/admin/users`, `PUT .../role`, `PUT .../active`

**ApiGateway**
- `admin` authorization policy requiring Admin role
- `/admin/**` route forwarded to UserManagementService

**Frontend**
- `AdminRoute` component for role-based route guard
- `AdminUserList` page with promote/demote and deactivate/activate actions
- Admin nav group visible only to Admin-role users

Closes #16

Generated with [Claude Code](https://claude.ai/code)