### PR TITLE
feat: responsive mobile sidebar drawer

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { NavLink, Outlet } from 'react-router-dom'
-import { Users, Building2, BarChart3, CheckSquare, LayoutDashboard, ChevronLeft, ChevronRight, ShieldCheck } from 'lucide-react'
+import { Users, Building2, BarChart3, CheckSquare, LayoutDashboard, ChevronLeft, ChevronRight, ShieldCheck, X } from 'lucide-react'
 import TopBar from './TopBar.jsx'
 import { useAuth } from '../context/AuthContext.jsx'
 import { cn } from '../lib/utils'
@@ -37,37 +37,72 @@ const adminNavGroup = {
 
 export default function Layout() {
   const [collapsed, setCollapsed] = useState(false)
+  const [mobileOpen, setMobileOpen] = useState(false)
   const { user } = useAuth()
   const isAdmin = user?.role === 'Admin'
 
   return (
     <div className="flex flex-col min-h-screen">
-      <TopBar />
+      <TopBar onMenuClick={() => setMobileOpen(o => !o)} />
 
       <div className="flex flex-1 min-h-0">
-        {/* Sidebar */}
+        {/* Mobile backdrop overlay */}
+        {mobileOpen && (
+          <div
+            className="fixed inset-0 z-30 bg-black/50 md:hidden"
+            onClick={() => setMobileOpen(false)}
+            aria-hidden="true"
+          />
+        )}
+
+        {/* Sidebar — fixed drawer on mobile, sticky inline on desktop */}
         <aside
           className={cn(
-            'flex flex-col flex-shrink-0 bg-sidebar text-sidebar-foreground transition-[width] duration-200 ease-in-out sticky top-14 h-[calc(100vh-56px)] z-10 overflow-hidden',
-            collapsed ? 'w-16' : 'w-60'
+            'flex flex-col bg-sidebar text-sidebar-foreground overflow-hidden',
+            // Mobile: fixed full-height drawer, slides in from left
+            'fixed top-0 bottom-0 left-0 z-40 w-72',
+            'transition-transform duration-300 ease-in-out',
+            mobileOpen ? 'translate-x-0' : '-translate-x-full',
+            // Desktop (md+): inline sticky sidebar, reset mobile overrides
+            'md:sticky md:top-14 md:bottom-auto md:z-10 md:flex-shrink-0',
+            'md:h-[calc(100vh-56px)] md:translate-x-0',
+            'md:transition-[width] md:duration-200 md:ease-in-out',
+            collapsed ? 'md:w-16' : 'md:w-60',
           )}
         >
           {/* Sidebar header */}
           <div
             className={cn(
-              'flex items-center h-14 border-b border-sidebar-border flex-shrink-0 px-4',
-              collapsed ? 'justify-center' : 'justify-between'
+              'flex items-center h-14 border-b border-sidebar-border flex-shrink-0 px-4 justify-between',
+              collapsed && 'md:justify-center',
             )}
           >
-            {!collapsed && (
-              <span className="text-lg font-bold tracking-wide text-white select-none">CRM</span>
-            )}
+            {/* Logo — always visible on mobile; hidden on desktop when collapsed */}
+            <span
+              className={cn(
+                'text-lg font-bold tracking-wide text-white select-none',
+                collapsed && 'md:hidden',
+              )}
+            >
+              CRM
+            </span>
+
+            {/* Desktop: collapse/expand toggle */}
             <button
-              className="text-sidebar-muted hover:text-sidebar-foreground hover:bg-sidebar-accent rounded p-1 flex items-center transition-colors"
+              className="hidden md:flex text-sidebar-muted hover:text-sidebar-foreground hover:bg-sidebar-accent rounded p-1 items-center transition-colors"
               onClick={() => setCollapsed(c => !c)}
               title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
             >
               {collapsed ? <ChevronRight size={16} /> : <ChevronLeft size={16} />}
+            </button>
+
+            {/* Mobile: close drawer button */}
+            <button
+              className="flex md:hidden text-sidebar-muted hover:text-sidebar-foreground hover:bg-sidebar-accent rounded p-1 items-center transition-colors"
+              onClick={() => setMobileOpen(false)}
+              title="Close menu"
+            >
+              <X size={16} />
             </button>
           </div>
 
@@ -75,26 +110,33 @@ export default function Layout() {
           <nav className="flex-1 overflow-y-auto py-3">
             {[...navGroups, ...(isAdmin ? [adminNavGroup] : [])].map(group => (
               <div key={group.label} className="mb-1">
-                {!collapsed && (
-                  <div className="px-4 pt-2 pb-1 text-[11px] font-semibold uppercase tracking-widest text-sidebar-muted select-none">
-                    {group.label}
-                  </div>
-                )}
+                {/* Group label: always show on mobile; hide on desktop when collapsed */}
+                <div
+                  className={cn(
+                    'px-4 pt-2 pb-1 text-[11px] font-semibold uppercase tracking-widest text-sidebar-muted select-none',
+                    collapsed ? 'md:hidden' : '',
+                  )}
+                >
+                  {group.label}
+                </div>
                 {group.items.map(({ to, label, Icon }) => (
                   <NavLink
                     key={to}
                     to={to}
                     title={collapsed ? label : undefined}
+                    onClick={() => setMobileOpen(false)}
                     className={({ isActive }) =>
                       cn(
                         'flex items-center gap-2.5 py-2 text-sm font-medium text-slate-400 hover:bg-slate-700 hover:text-slate-100 transition-colors no-underline',
-                        collapsed ? 'justify-center px-0' : 'px-4',
-                        isActive && 'bg-blue-600 text-white hover:bg-blue-600/90 hover:text-white'
+                        // Mobile: always padded; Desktop: icon-only when collapsed
+                        collapsed ? 'px-4 md:justify-center md:px-0' : 'px-4',
+                        isActive && 'bg-blue-600 text-white hover:bg-blue-600/90 hover:text-white',
                       )
                     }
                   >
                     <Icon size={18} className="flex-shrink-0" />
-                    {!collapsed && <span>{label}</span>}
+                    {/* Label: always show on mobile; hide on desktop when collapsed */}
+                    <span className={cn(collapsed && 'md:hidden')}>{label}</span>
                   </NavLink>
                 ))}
               </div>
@@ -103,7 +145,7 @@ export default function Layout() {
         </aside>
 
         {/* Main content */}
-        <main className="flex-1 min-w-0 p-6 bg-gray-50">
+        <main className="flex-1 min-w-0 p-4 md:p-6 bg-gray-50 overflow-x-hidden">
           <Outlet />
         </main>
       </div>

--- a/frontend/src/components/TopBar.jsx
+++ b/frontend/src/components/TopBar.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
-import { Search, Bell, ChevronDown, User, LogOut } from 'lucide-react'
+import { Search, Bell, ChevronDown, User, LogOut, Menu } from 'lucide-react'
 import { useAuth } from '../context/AuthContext.jsx'
 import {
   DropdownMenu,
@@ -20,7 +20,7 @@ function getInitials(email) {
   return local.slice(0, 2).toUpperCase()
 }
 
-export default function TopBar() {
+export default function TopBar({ onMenuClick }) {
   const { user, logout } = useAuth()
   const navigate = useNavigate()
   const [searchQuery, setSearchQuery] = useState('')
@@ -38,9 +38,18 @@ export default function TopBar() {
   const initials = getInitials(user?.email)
 
   return (
-    <header className="h-14 sticky top-0 z-20 bg-white border-b border-gray-200 flex items-center justify-between px-5 gap-4 flex-shrink-0">
+    <header className="h-14 sticky top-0 z-20 bg-white border-b border-gray-200 flex items-center justify-between px-3 md:px-5 gap-2 md:gap-4 flex-shrink-0">
+      {/* Hamburger — mobile only */}
+      <button
+        className="md:hidden flex items-center justify-center w-9 h-9 rounded-lg hover:bg-gray-100 text-gray-600 transition-colors flex-shrink-0"
+        onClick={onMenuClick}
+        aria-label="Open navigation menu"
+      >
+        <Menu size={20} />
+      </button>
+
       {/* Search */}
-      <div className="flex-1 max-w-md">
+      <div className="flex-1 max-w-md min-w-0">
         <form className="relative flex items-center" onSubmit={handleSearchSubmit} role="search">
           <Search className="absolute left-2.5 h-4 w-4 text-gray-400 pointer-events-none" />
           <input


### PR DESCRIPTION
Make the layout responsive for narrow viewports.

- Sidebar collapses to a hamburger drawer on mobile
- Backdrop overlay closes drawer on tap
- All pages usable on narrow viewports (overflow fixes, responsive padding)
- Desktop sticky/collapsible sidebar behavior unchanged

Closes #17

Generated with [Claude Code](https://claude.ai/code)