### PR TITLE
feat: DLQ monitoring and exponential backoff retry policies

### DIFF
--- a/DealService/src/DealService.Tests/Infrastructure/DlqHealthCheckTests.cs
+++ b/DealService/src/DealService.Tests/Infrastructure/DlqHealthCheckTests.cs
@@ -1,0 +1,127 @@
+using System.Net;
+using DealService.Infrastructure;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Moq;
+
+namespace DealService.Tests.Infrastructure;
+
+public class DlqHealthCheckTests
+{
+    private static IConfiguration BuildConfig(string host = "localhost", int managementPort = 15672,
+        string username = "guest", string password = "guest", string vhost = "/")
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["RabbitMQ:Host"] = host,
+                ["RabbitMQ:ManagementPort"] = managementPort.ToString(),
+                ["RabbitMQ:Username"] = username,
+                ["RabbitMQ:Password"] = password,
+                ["RabbitMQ:VirtualHost"] = vhost
+            })
+            .Build();
+    }
+
+    private static IHttpClientFactory BuildFactory(string responseBody, HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        var handler = new MockHttpMessageHandler(responseBody, statusCode);
+        var client = new HttpClient(handler);
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
+        return factory.Object;
+    }
+
+    private static HealthCheckContext BuildContext() =>
+        new() { Registration = new HealthCheckRegistration("rabbitmq-dlq", Mock.Of<IHealthCheck>(), null, null) };
+
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsHealthy_WhenNoErrorQueues()
+    {
+        var json = """[{"name":"contact-deleted","messages":0}]""";
+        var check = new DlqHealthCheck(BuildFactory(json), BuildConfig());
+
+        var result = await check.CheckHealthAsync(BuildContext());
+
+        result.Status.Should().Be(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsDegraded_WhenErrorQueueHasMessages()
+    {
+        var json = """[{"name":"contact-deleted_error","messages":2}]""";
+        var check = new DlqHealthCheck(BuildFactory(json), BuildConfig());
+
+        var result = await check.CheckHealthAsync(BuildContext());
+
+        result.Status.Should().Be(HealthStatus.Degraded);
+        result.Data.Should().ContainKey("contact-deleted_error");
+        result.Data["contact-deleted_error"].Should().Be(2L);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_IgnoresErrorQueues_WithZeroMessages()
+    {
+        var json = """[{"name":"contact-deleted_error","messages":0}]""";
+        var check = new DlqHealthCheck(BuildFactory(json), BuildConfig());
+
+        var result = await check.CheckHealthAsync(BuildContext());
+
+        result.Status.Should().Be(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsDegraded_WhenManagementApiReturnsNonSuccess()
+    {
+        var check = new DlqHealthCheck(BuildFactory(string.Empty, HttpStatusCode.Forbidden), BuildConfig());
+
+        var result = await check.CheckHealthAsync(BuildContext());
+
+        result.Status.Should().Be(HealthStatus.Degraded);
+        result.Description.Should().Contain("403");
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsDegraded_WhenManagementApiUnreachable()
+    {
+        var handler = new ThrowingHttpMessageHandler(new HttpRequestException("Connection refused"));
+        var client = new HttpClient(handler);
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
+
+        var check = new DlqHealthCheck(factory.Object, BuildConfig());
+
+        var result = await check.CheckHealthAsync(BuildContext());
+
+        result.Status.Should().Be(HealthStatus.Degraded);
+        result.Description.Should().Contain("unreachable");
+    }
+
+    private sealed class MockHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly string _responseContent;
+        private readonly HttpStatusCode _statusCode;
+
+        public MockHttpMessageHandler(string responseContent, HttpStatusCode statusCode = HttpStatusCode.OK)
+        {
+            _responseContent = responseContent;
+            _statusCode = statusCode;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(_statusCode)
+            {
+                Content = new StringContent(_responseContent)
+            });
+    }
+
+    private sealed class ThrowingHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Exception _exception;
+        public ThrowingHttpMessageHandler(Exception exception) => _exception = exception;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            throw _exception;
+    }
+}

--- a/DealService/src/DealService/Infrastructure/DlqHealthCheck.cs
+++ b/DealService/src/DealService/Infrastructure/DlqHealthCheck.cs
@@ -1,0 +1,74 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace DealService.Infrastructure;
+
+public class DlqHealthCheck : IHealthCheck
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IConfiguration _configuration;
+
+    public DlqHealthCheck(IHttpClientFactory httpClientFactory, IConfiguration configuration)
+    {
+        _httpClientFactory = httpClientFactory;
+        _configuration = configuration;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var host = _configuration["RabbitMQ:Host"] ?? "localhost";
+        var managementPort = _configuration.GetValue<int>("RabbitMQ:ManagementPort", 15672);
+        var username = _configuration["RabbitMQ:Username"] ?? "guest";
+        var password = _configuration["RabbitMQ:Password"] ?? "guest";
+        var vhost = Uri.EscapeDataString(_configuration["RabbitMQ:VirtualHost"] ?? "/");
+
+        try
+        {
+            using var client = _httpClientFactory.CreateClient();
+            var credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}"));
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+            client.Timeout = TimeSpan.FromSeconds(5);
+
+            var url = $"http://{host}:{managementPort}/api/queues/{vhost}";
+            var response = await client.GetAsync(url, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+                return HealthCheckResult.Degraded(
+                    $"RabbitMQ management API returned {(int)response.StatusCode}");
+
+            var json = await response.Content.ReadAsStringAsync(cancellationToken);
+            var queues = JsonSerializer.Deserialize<List<QueueStats>>(json,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            var errorQueues = queues?
+                .Where(q => q.Name.EndsWith("_error", StringComparison.Ordinal) && q.Messages > 0)
+                .ToList();
+
+            if (errorQueues == null || errorQueues.Count == 0)
+                return HealthCheckResult.Healthy("No messages in dead-letter queues.");
+
+            var data = errorQueues.ToDictionary(q => q.Name, q => (object)q.Messages);
+            return HealthCheckResult.Degraded(
+                $"{errorQueues.Count} dead-letter queue(s) have unprocessed messages.",
+                data: data);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
+        {
+            return HealthCheckResult.Degraded($"RabbitMQ management API unreachable: {ex.Message}");
+        }
+    }
+
+    private sealed class QueueStats
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("messages")]
+        public long Messages { get; set; }
+    }
+}

--- a/DealService/src/DealService/Program.cs
+++ b/DealService/src/DealService/Program.cs
@@ -2,6 +2,7 @@ using OpenTelemetry.Exporter;
 using Serilog.Enrichers.OpenTelemetry;
 using DealService.Consumers;
 using DealService.Data;
+using DealService.Infrastructure;
 using DealService.Middleware;
 using DealService.Repository;
 using DealService.Services;
@@ -61,14 +62,20 @@ builder.Services.AddMassTransit(x =>
       h.Username(builder.Configuration["RabbitMQ:Username"] ?? "guest");
       h.Password(builder.Configuration["RabbitMQ:Password"] ?? "guest");
     });
+    cfg.UseMessageRetry(r => r.Exponential(5,
+      TimeSpan.FromSeconds(1),
+      TimeSpan.FromSeconds(60),
+      TimeSpan.FromSeconds(5)));
     cfg.ConfigureEndpoints(ctx);
   });
 });
 
+builder.Services.AddHttpClient();
 builder.Services.AddHealthChecks()
     .AddNpgSql(
         builder.Configuration.GetConnectionString("DealDbConnection") ?? string.Empty,
-        name: "deal-db");
+        name: "deal-db")
+    .AddCheck<DlqHealthCheck>("rabbitmq-dlq", tags: ["messaging"]);
 
 builder.Services.AddOpenTelemetry()
     .WithTracing(tracing => tracing

--- a/DealService/src/DealService/appsettings.Development.json
+++ b/DealService/src/DealService/appsettings.Development.json
@@ -15,6 +15,7 @@
   "RabbitMQ": {
     "Host": "localhost",
     "Username": "guest",
-    "Password": "guest"
+    "Password": "guest",
+    "ManagementPort": 15672
   }
 }

--- a/DealService/src/DealService/appsettings.json
+++ b/DealService/src/DealService/appsettings.json
@@ -18,6 +18,7 @@
   },
   "RabbitMQ": {
     "Host": "rabbitmq",
-    "VirtualHost": "/"
+    "VirtualHost": "/",
+    "ManagementPort": 15672
   }
 }

--- a/ReportingService/src/ReportingService.Tests/Infrastructure/DlqHealthCheckTests.cs
+++ b/ReportingService/src/ReportingService.Tests/Infrastructure/DlqHealthCheckTests.cs
@@ -1,0 +1,152 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using ReportingService.Infrastructure;
+
+namespace ReportingService.Tests.Infrastructure;
+
+public class DlqHealthCheckTests
+{
+    private static IConfiguration BuildConfig(string host = "localhost", int managementPort = 15672,
+        string username = "guest", string password = "guest", string vhost = "/")
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["RabbitMQ:Host"] = host,
+                ["RabbitMQ:ManagementPort"] = managementPort.ToString(),
+                ["RabbitMQ:Username"] = username,
+                ["RabbitMQ:Password"] = password,
+                ["RabbitMQ:VirtualHost"] = vhost
+            })
+            .Build();
+    }
+
+    private static IHttpClientFactory BuildFactory(string responseBody, HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        var handler = new MockHttpMessageHandler(responseBody, statusCode);
+        return new TestHttpClientFactory(new HttpClient(handler));
+    }
+
+    private static HealthCheckContext BuildContext() =>
+        new() { Registration = new HealthCheckRegistration("rabbitmq-dlq", new NoOpHealthCheck(), null, null) };
+
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsHealthy_WhenNoErrorQueues()
+    {
+        var json = """[{"name":"deal-created","messages":0},{"name":"activity-logged","messages":0}]""";
+        var check = new DlqHealthCheck(BuildFactory(json), BuildConfig());
+
+        var result = await check.CheckHealthAsync(BuildContext());
+
+        result.Status.Should().Be(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsDegraded_WhenErrorQueueHasMessages()
+    {
+        var json = """[{"name":"deal-created_error","messages":7}]""";
+        var check = new DlqHealthCheck(BuildFactory(json), BuildConfig());
+
+        var result = await check.CheckHealthAsync(BuildContext());
+
+        result.Status.Should().Be(HealthStatus.Degraded);
+        result.Data.Should().ContainKey("deal-created_error");
+        result.Data["deal-created_error"].Should().Be(7L);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_IgnoresErrorQueues_WithZeroMessages()
+    {
+        var json = """[{"name":"deal-created_error","messages":0},{"name":"activity-logged_error","messages":0}]""";
+        var check = new DlqHealthCheck(BuildFactory(json), BuildConfig());
+
+        var result = await check.CheckHealthAsync(BuildContext());
+
+        result.Status.Should().Be(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsDegraded_WhenManagementApiReturnsNonSuccess()
+    {
+        var check = new DlqHealthCheck(BuildFactory(string.Empty, HttpStatusCode.Unauthorized), BuildConfig());
+
+        var result = await check.CheckHealthAsync(BuildContext());
+
+        result.Status.Should().Be(HealthStatus.Degraded);
+        result.Description.Should().Contain("401");
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsDegraded_WhenManagementApiUnreachable()
+    {
+        var handler = new ThrowingHttpMessageHandler(new HttpRequestException("Connection refused"));
+        var check = new DlqHealthCheck(new TestHttpClientFactory(new HttpClient(handler)), BuildConfig());
+
+        var result = await check.CheckHealthAsync(BuildContext());
+
+        result.Status.Should().Be(HealthStatus.Degraded);
+        result.Description.Should().Contain("unreachable");
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_ReportsDegraded_WithMultipleReportingErrorQueues()
+    {
+        var json = """
+            [
+              {"name":"deal-created_error","messages":2},
+              {"name":"deal-stage-changed_error","messages":1},
+              {"name":"deal-created","messages":0}
+            ]
+            """;
+        var check = new DlqHealthCheck(BuildFactory(json), BuildConfig());
+
+        var result = await check.CheckHealthAsync(BuildContext());
+
+        result.Status.Should().Be(HealthStatus.Degraded);
+        result.Data.Should().HaveCount(2);
+        result.Data.Should().ContainKey("deal-created_error");
+        result.Data.Should().ContainKey("deal-stage-changed_error");
+    }
+
+    private sealed class TestHttpClientFactory : IHttpClientFactory
+    {
+        private readonly HttpClient _client;
+        public TestHttpClientFactory(HttpClient client) => _client = client;
+        public HttpClient CreateClient(string name) => _client;
+    }
+
+    private sealed class NoOpHealthCheck : IHealthCheck
+    {
+        public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default) =>
+            Task.FromResult(HealthCheckResult.Healthy());
+    }
+
+    private sealed class MockHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly string _responseContent;
+        private readonly HttpStatusCode _statusCode;
+
+        public MockHttpMessageHandler(string responseContent, HttpStatusCode statusCode = HttpStatusCode.OK)
+        {
+            _responseContent = responseContent;
+            _statusCode = statusCode;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(_statusCode)
+            {
+                Content = new StringContent(_responseContent)
+            });
+    }
+
+    private sealed class ThrowingHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Exception _exception;
+        public ThrowingHttpMessageHandler(Exception exception) => _exception = exception;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            throw _exception;
+    }
+}

--- a/ReportingService/src/ReportingService/Infrastructure/DlqHealthCheck.cs
+++ b/ReportingService/src/ReportingService/Infrastructure/DlqHealthCheck.cs
@@ -1,0 +1,74 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace ReportingService.Infrastructure;
+
+public class DlqHealthCheck : IHealthCheck
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IConfiguration _configuration;
+
+    public DlqHealthCheck(IHttpClientFactory httpClientFactory, IConfiguration configuration)
+    {
+        _httpClientFactory = httpClientFactory;
+        _configuration = configuration;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var host = _configuration["RabbitMQ:Host"] ?? "localhost";
+        var managementPort = _configuration.GetValue<int>("RabbitMQ:ManagementPort", 15672);
+        var username = _configuration["RabbitMQ:Username"] ?? "guest";
+        var password = _configuration["RabbitMQ:Password"] ?? "guest";
+        var vhost = Uri.EscapeDataString(_configuration["RabbitMQ:VirtualHost"] ?? "/");
+
+        try
+        {
+            using var client = _httpClientFactory.CreateClient();
+            var credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}"));
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+            client.Timeout = TimeSpan.FromSeconds(5);
+
+            var url = $"http://{host}:{managementPort}/api/queues/{vhost}";
+            var response = await client.GetAsync(url, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+                return HealthCheckResult.Degraded(
+                    $"RabbitMQ management API returned {(int)response.StatusCode}");
+
+            var json = await response.Content.ReadAsStringAsync(cancellationToken);
+            var queues = JsonSerializer.Deserialize<List<QueueStats>>(json,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            var errorQueues = queues?
+                .Where(q => q.Name.EndsWith("_error", StringComparison.Ordinal) && q.Messages > 0)
+                .ToList();
+
+            if (errorQueues == null || errorQueues.Count == 0)
+                return HealthCheckResult.Healthy("No messages in dead-letter queues.");
+
+            var data = errorQueues.ToDictionary(q => q.Name, q => (object)q.Messages);
+            return HealthCheckResult.Degraded(
+                $"{errorQueues.Count} dead-letter queue(s) have unprocessed messages.",
+                data: data);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
+        {
+            return HealthCheckResult.Degraded($"RabbitMQ management API unreachable: {ex.Message}");
+        }
+    }
+
+    private sealed class QueueStats
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("messages")]
+        public long Messages { get; set; }
+    }
+}

--- a/ReportingService/src/ReportingService/Program.cs
+++ b/ReportingService/src/ReportingService/Program.cs
@@ -6,6 +6,7 @@ using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using ReportingService.Consumers;
 using ReportingService.Data;
+using ReportingService.Infrastructure;
 using ReportingService.Middleware;
 using ReportingService.Models;
 using Serilog;
@@ -45,14 +46,20 @@ builder.Services.AddMassTransit(x =>
             h.Username(builder.Configuration["RabbitMQ:Username"] ?? "guest");
             h.Password(builder.Configuration["RabbitMQ:Password"] ?? "guest");
         });
+        cfg.UseMessageRetry(r => r.Exponential(5,
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromSeconds(60),
+            TimeSpan.FromSeconds(5)));
         cfg.ConfigureEndpoints(ctx);
     });
 });
 
+builder.Services.AddHttpClient();
 builder.Services.AddHealthChecks()
     .AddNpgSql(
         builder.Configuration.GetConnectionString("ReportingDbConnection") ?? string.Empty,
-        name: "reporting-db");
+        name: "reporting-db")
+    .AddCheck<DlqHealthCheck>("rabbitmq-dlq", tags: ["messaging"]);
 
 builder.Services.AddOpenTelemetry()
     .WithTracing(tracing => tracing

--- a/ReportingService/src/ReportingService/appsettings.Development.json
+++ b/ReportingService/src/ReportingService/appsettings.Development.json
@@ -11,6 +11,7 @@
   "RabbitMQ": {
     "Host": "localhost",
     "Username": "guest",
-    "Password": "guest"
+    "Password": "guest",
+    "ManagementPort": 15672
   }
 }

--- a/ReportingService/src/ReportingService/appsettings.json
+++ b/ReportingService/src/ReportingService/appsettings.json
@@ -14,6 +14,7 @@
   },
   "RabbitMQ": {
     "Host": "rabbitmq",
-    "VirtualHost": "/"
+    "VirtualHost": "/",
+    "ManagementPort": 15672
   }
 }

--- a/UserManagementService/src/UserManagementService.Tests/Infrastructure/DlqHealthCheckTests.cs
+++ b/UserManagementService/src/UserManagementService.Tests/Infrastructure/DlqHealthCheckTests.cs
@@ -1,0 +1,149 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Moq;
+using UserManagementService.Infrastructure;
+
+namespace UserManagementService.Tests.Infrastructure;
+
+public class DlqHealthCheckTests
+{
+    private static IConfiguration BuildConfig(string host = "localhost", int managementPort = 15672,
+        string username = "guest", string password = "guest", string vhost = "/")
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["RabbitMQ:Host"] = host,
+                ["RabbitMQ:ManagementPort"] = managementPort.ToString(),
+                ["RabbitMQ:Username"] = username,
+                ["RabbitMQ:Password"] = password,
+                ["RabbitMQ:VirtualHost"] = vhost
+            })
+            .Build();
+    }
+
+    private static IHttpClientFactory BuildFactory(string responseBody, HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        var handler = new MockHttpMessageHandler(responseBody, statusCode);
+        var client = new HttpClient(handler);
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
+        return factory.Object;
+    }
+
+    private static HealthCheckContext BuildContext() =>
+        new() { Registration = new HealthCheckRegistration("rabbitmq-dlq", Mock.Of<IHealthCheck>(), null, null) };
+
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsHealthy_WhenNoErrorQueues()
+    {
+        var json = """[{"name":"user-management-service","messages":0}]""";
+        var check = new DlqHealthCheck(BuildFactory(json), BuildConfig());
+
+        var result = await check.CheckHealthAsync(BuildContext());
+
+        result.Status.Should().Be(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsDegraded_WhenErrorQueueHasMessages()
+    {
+        var json = """[{"name":"user-registered_error","messages":3},{"name":"user-registered","messages":0}]""";
+        var check = new DlqHealthCheck(BuildFactory(json), BuildConfig());
+
+        var result = await check.CheckHealthAsync(BuildContext());
+
+        result.Status.Should().Be(HealthStatus.Degraded);
+        result.Data.Should().ContainKey("user-registered_error");
+        result.Data["user-registered_error"].Should().Be(3L);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_IgnoresErrorQueues_WithZeroMessages()
+    {
+        var json = """[{"name":"user-registered_error","messages":0}]""";
+        var check = new DlqHealthCheck(BuildFactory(json), BuildConfig());
+
+        var result = await check.CheckHealthAsync(BuildContext());
+
+        result.Status.Should().Be(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsDegraded_WhenManagementApiReturnsNonSuccess()
+    {
+        var check = new DlqHealthCheck(BuildFactory(string.Empty, HttpStatusCode.Unauthorized), BuildConfig());
+
+        var result = await check.CheckHealthAsync(BuildContext());
+
+        result.Status.Should().Be(HealthStatus.Degraded);
+        result.Description.Should().Contain("401");
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsDegraded_WhenManagementApiUnreachable()
+    {
+        var handler = new ThrowingHttpMessageHandler(new HttpRequestException("Connection refused"));
+        var client = new HttpClient(handler);
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
+
+        var check = new DlqHealthCheck(factory.Object, BuildConfig());
+
+        var result = await check.CheckHealthAsync(BuildContext());
+
+        result.Status.Should().Be(HealthStatus.Degraded);
+        result.Description.Should().Contain("unreachable");
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_ReportsDegraded_WithMultipleErrorQueues()
+    {
+        var json = """
+            [
+              {"name":"queue-a_error","messages":1},
+              {"name":"queue-b_error","messages":5},
+              {"name":"queue-c","messages":10}
+            ]
+            """;
+        var check = new DlqHealthCheck(BuildFactory(json), BuildConfig());
+
+        var result = await check.CheckHealthAsync(BuildContext());
+
+        result.Status.Should().Be(HealthStatus.Degraded);
+        result.Data.Should().HaveCount(2);
+        result.Data.Should().ContainKey("queue-a_error");
+        result.Data.Should().ContainKey("queue-b_error");
+        result.Data.Should().NotContainKey("queue-c");
+    }
+
+    private sealed class MockHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly string _responseContent;
+        private readonly HttpStatusCode _statusCode;
+
+        public MockHttpMessageHandler(string responseContent, HttpStatusCode statusCode = HttpStatusCode.OK)
+        {
+            _responseContent = responseContent;
+            _statusCode = statusCode;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(_statusCode)
+            {
+                Content = new StringContent(_responseContent)
+            });
+    }
+
+    private sealed class ThrowingHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Exception _exception;
+        public ThrowingHttpMessageHandler(Exception exception) => _exception = exception;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            throw _exception;
+    }
+}

--- a/UserManagementService/src/UserManagementService/Infrastructure/DlqHealthCheck.cs
+++ b/UserManagementService/src/UserManagementService/Infrastructure/DlqHealthCheck.cs
@@ -1,0 +1,74 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace UserManagementService.Infrastructure;
+
+public class DlqHealthCheck : IHealthCheck
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IConfiguration _configuration;
+
+    public DlqHealthCheck(IHttpClientFactory httpClientFactory, IConfiguration configuration)
+    {
+        _httpClientFactory = httpClientFactory;
+        _configuration = configuration;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var host = _configuration["RabbitMQ:Host"] ?? "localhost";
+        var managementPort = _configuration.GetValue<int>("RabbitMQ:ManagementPort", 15672);
+        var username = _configuration["RabbitMQ:Username"] ?? "guest";
+        var password = _configuration["RabbitMQ:Password"] ?? "guest";
+        var vhost = Uri.EscapeDataString(_configuration["RabbitMQ:VirtualHost"] ?? "/");
+
+        try
+        {
+            using var client = _httpClientFactory.CreateClient();
+            var credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}"));
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+            client.Timeout = TimeSpan.FromSeconds(5);
+
+            var url = $"http://{host}:{managementPort}/api/queues/{vhost}";
+            var response = await client.GetAsync(url, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+                return HealthCheckResult.Degraded(
+                    $"RabbitMQ management API returned {(int)response.StatusCode}");
+
+            var json = await response.Content.ReadAsStringAsync(cancellationToken);
+            var queues = JsonSerializer.Deserialize<List<QueueStats>>(json,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            var errorQueues = queues?
+                .Where(q => q.Name.EndsWith("_error", StringComparison.Ordinal) && q.Messages > 0)
+                .ToList();
+
+            if (errorQueues == null || errorQueues.Count == 0)
+                return HealthCheckResult.Healthy("No messages in dead-letter queues.");
+
+            var data = errorQueues.ToDictionary(q => q.Name, q => (object)q.Messages);
+            return HealthCheckResult.Degraded(
+                $"{errorQueues.Count} dead-letter queue(s) have unprocessed messages.",
+                data: data);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
+        {
+            return HealthCheckResult.Degraded($"RabbitMQ management API unreachable: {ex.Message}");
+        }
+    }
+
+    private sealed class QueueStats
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("messages")]
+        public long Messages { get; set; }
+    }
+}

--- a/UserManagementService/src/UserManagementService/Program.cs
+++ b/UserManagementService/src/UserManagementService/Program.cs
@@ -3,6 +3,7 @@ using Serilog.Enrichers.OpenTelemetry;
 using Microsoft.EntityFrameworkCore;
 using UserManagementService.Consumers;
 using UserManagementService.Data;
+using UserManagementService.Infrastructure;
 using UserManagementService.Middleware;
 using UserManagementService.Repository;
 using UserManagementService.Services;
@@ -46,15 +47,21 @@ builder.Services.AddMassTransit(x =>
       h.Username(builder.Configuration["RabbitMQ:Username"] ?? "guest");
       h.Password(builder.Configuration["RabbitMQ:Password"] ?? "guest");
     });
+    cfg.UseMessageRetry(r => r.Exponential(5,
+      TimeSpan.FromSeconds(1),
+      TimeSpan.FromSeconds(60),
+      TimeSpan.FromSeconds(5)));
     cfg.ConfigureEndpoints(ctx);
   });
 });
 
 // Health checks
+builder.Services.AddHttpClient();
 builder.Services.AddHealthChecks()
     .AddNpgSql(
         builder.Configuration.GetConnectionString("UserManagementDbConnection") ?? string.Empty,
-        name: "user-management-db");
+        name: "user-management-db")
+    .AddCheck<DlqHealthCheck>("rabbitmq-dlq", tags: ["messaging"]);
 
 // OpenTelemetry
 builder.Services.AddOpenTelemetry()

--- a/UserManagementService/src/UserManagementService/appsettings.Development.json
+++ b/UserManagementService/src/UserManagementService/appsettings.Development.json
@@ -11,6 +11,7 @@
   "RabbitMQ": {
     "Host": "localhost",
     "Username": "guest",
-    "Password": "guest"
+    "Password": "guest",
+    "ManagementPort": 15672
   }
 }

--- a/UserManagementService/src/UserManagementService/appsettings.json
+++ b/UserManagementService/src/UserManagementService/appsettings.json
@@ -19,6 +19,7 @@
   },
   "RabbitMQ": {
     "Host": "rabbitmq",
-    "VirtualHost": "/"
+    "VirtualHost": "/",
+    "ManagementPort": 15672
   }
 }


### PR DESCRIPTION
Implements #21 - Dead-letter queue monitoring and retry policies.

- MassTransit retry with exponential backoff (5 retries, 1s–60s) on all consumers
- `DlqHealthCheck` queries RabbitMQ Management API for `_error` queue depths
- Health check exposed at `/health` with `messaging` tag in UserManagementService, DealService, ReportingService
- 16 new unit tests

Generated with [Claude Code](https://claude.ai/code)