### PR TITLE
feat: rate limiting at the API Gateway (issue #22)

### DIFF
--- a/ApiGateway/src/ApiGateway/Program.cs
+++ b/ApiGateway/src/ApiGateway/Program.cs
@@ -2,12 +2,16 @@ using OpenTelemetry.Exporter;
 using Serilog.Enrichers.OpenTelemetry;
 using ApiGateway.Middleware;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.IdentityModel.Tokens;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using Serilog;
 using Serilog.Formatting.Compact;
+using System.Globalization;
+using System.Security.Claims;
 using System.Text;
+using System.Threading.RateLimiting;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -44,6 +48,62 @@ builder.Services
 builder.Services.AddAuthorization(options =>
 {
   options.AddPolicy("admin", policy => policy.RequireRole("Admin"));
+});
+
+var rateLimitSettings = builder.Configuration.GetSection("RateLimiting");
+var perIpLimit = rateLimitSettings.GetValue("PerIpPermitLimit", 100);
+var perUserLimit = rateLimitSettings.GetValue("PerUserPermitLimit", 200);
+var windowSeconds = rateLimitSettings.GetValue("WindowSeconds", 60);
+var retryAfterSeconds = rateLimitSettings.GetValue("RetryAfterSeconds", 60).ToString(NumberFormatInfo.InvariantInfo);
+
+builder.Services.AddRateLimiter(options =>
+{
+  options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+
+  options.OnRejected = async (context, cancellationToken) =>
+  {
+    var retryAfter = context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfterTimeSpan)
+        ? ((int)retryAfterTimeSpan.TotalSeconds).ToString(NumberFormatInfo.InvariantInfo)
+        : retryAfterSeconds;
+
+    context.HttpContext.Response.Headers.RetryAfter = retryAfter;
+    await context.HttpContext.Response.WriteAsync("Too many requests. Please try again later.", cancellationToken);
+  };
+
+  // Chained global limiter: every request must satisfy both the per-IP and per-user buckets.
+  options.GlobalLimiter = PartitionedRateLimiter.CreateChained(
+      // Per-IP limiter — applies to all requests
+      PartitionedRateLimiter.Create<HttpContext, string>(context =>
+      {
+        var ip = context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        return RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: $"ip:{ip}",
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+              PermitLimit = perIpLimit,
+              Window = TimeSpan.FromSeconds(windowSeconds),
+              QueueLimit = 0
+            });
+      }),
+      // Per-user limiter — applies only to authenticated requests (falls through for anonymous)
+      PartitionedRateLimiter.Create<HttpContext, string>(context =>
+      {
+        var userId = context.User.FindFirstValue("UserId")
+            ?? context.User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+        if (userId is null)
+          return RateLimitPartition.GetNoLimiter("anonymous");
+
+        return RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: $"user:{userId}",
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+              PermitLimit = perUserLimit,
+              Window = TimeSpan.FromSeconds(windowSeconds),
+              QueueLimit = 0
+            });
+      })
+  );
 });
 
 builder.Services.AddReverseProxy()
@@ -89,6 +149,7 @@ app.UseCors();
 app.UseAuthentication();
 app.UseMiddleware<CorrelationIdMiddleware>();
 app.UseAuthorization();
+app.UseRateLimiter();
 app.MapHealthChecks("/health");
 app.MapReverseProxy();
 

--- a/ApiGateway/src/ApiGateway/appsettings.json
+++ b/ApiGateway/src/ApiGateway/appsettings.json
@@ -1,4 +1,10 @@
 {
+  "RateLimiting": {
+    "PerIpPermitLimit": 100,
+    "PerUserPermitLimit": 200,
+    "WindowSeconds": 60,
+    "RetryAfterSeconds": 60
+  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Information",


### PR DESCRIPTION
Add per-IP and per-user rate limiting to the YARP gateway.

- Per-IP: 100 req/60s (all traffic)
- Per-user (JWT subject): 200 req/60s (authenticated only)
- Returns HTTP 429 with Retry-After header on limit exceeded
- All limits configurable via RateLimiting section in appsettings.json

Closes #22

Generated with [Claude Code](https://claude.ai/code)