### PR TITLE
feat: soft delete and audit trail for CRM entities

### DIFF
--- a/AccountService/src/AccountService.Tests/Repository/AccountRepositoryTests.cs
+++ b/AccountService/src/AccountService.Tests/Repository/AccountRepositoryTests.cs
@@ -119,7 +119,7 @@ public class AccountRepositoryTests
   // ── DeleteAsync ───────────────────────────────────────────────────────────
 
   [Fact]
-  public async Task DeleteAsync_RemovesAccount()
+  public async Task DeleteAsync_SoftDeletesAccount()
   {
     using var ctx = CreateContext();
     var account = MakeAccount();
@@ -129,8 +129,27 @@ public class AccountRepositoryTests
 
     await repo.DeleteAsync(account.AccountId);
 
-    var deleted = await ctx.Accounts.FindAsync(account.AccountId);
-    deleted.Should().BeNull();
+    var softDeleted = await ctx.Accounts.IgnoreQueryFilters().FirstOrDefaultAsync(a => a.AccountId == account.AccountId);
+    softDeleted.Should().NotBeNull();
+    softDeleted!.IsDeleted.Should().BeTrue();
+    softDeleted.DeletedAt.Should().NotBeNull();
+  }
+
+  [Fact]
+  public async Task DeleteAsync_ExcludesAccountFromQueries()
+  {
+    using var ctx = CreateContext();
+    var account = MakeAccount();
+    ctx.Accounts.Add(account);
+    await ctx.SaveChangesAsync();
+    var repo = new AccountRepository(ctx);
+
+    await repo.DeleteAsync(account.AccountId);
+
+    var found = await repo.GetByIdAsync(account.AccountId);
+    found.Should().BeNull();
+    var all = await repo.GetAllAsync();
+    all.Should().NotContain(a => a.AccountId == account.AccountId);
   }
 
   [Fact]
@@ -142,5 +161,20 @@ public class AccountRepositoryTests
     var act = async () => await repo.DeleteAsync(Guid.NewGuid());
 
     await act.Should().NotThrowAsync();
+  }
+
+  // ── AuditLog ──────────────────────────────────────────────────────────────
+
+  [Fact]
+  public async Task AddAsync_CreatesAuditLogEntry()
+  {
+    using var ctx = CreateContext();
+    var repo = new AccountRepository(ctx);
+    var account = MakeAccount("Audit Corp");
+
+    await repo.AddAsync(account);
+
+    var auditLogs = await ctx.AuditLogs.Where(a => a.EntityId == account.AccountId.ToString()).ToListAsync();
+    auditLogs.Should().ContainSingle(a => a.Action == "Created");
   }
 }

--- a/AccountService/src/AccountService/Data/AccountDbContext.cs
+++ b/AccountService/src/AccountService/Data/AccountDbContext.cs
@@ -1,11 +1,108 @@
 using AccountService.Models;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using System.Security.Claims;
+using System.Text.Json;
 
 namespace AccountService.Data;
 
 public class AccountDbContext : DbContext
 {
-  public AccountDbContext(DbContextOptions<AccountDbContext> options) : base(options) { }
+  private readonly IHttpContextAccessor? _httpContextAccessor;
+
+  public AccountDbContext(DbContextOptions<AccountDbContext> options, IHttpContextAccessor? httpContextAccessor = null)
+    : base(options)
+  {
+    _httpContextAccessor = httpContextAccessor;
+  }
 
   public DbSet<Account> Accounts => Set<Account>();
+  public DbSet<AuditLog> AuditLogs => Set<AuditLog>();
+
+  protected override void OnModelCreating(ModelBuilder modelBuilder)
+  {
+    modelBuilder.Entity<Account>().HasQueryFilter(a => !a.IsDeleted);
+  }
+
+  public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+  {
+    var auditEntries = BuildAuditEntries();
+    var result = await base.SaveChangesAsync(cancellationToken);
+    if (auditEntries.Count > 0)
+    {
+      AuditLogs.AddRange(auditEntries);
+      await base.SaveChangesAsync(cancellationToken);
+    }
+    return result;
+  }
+
+  private List<AuditLog> BuildAuditEntries()
+  {
+    ChangeTracker.DetectChanges();
+    var userId = GetCurrentUserId();
+    var entries = new List<AuditLog>();
+
+    foreach (var entry in ChangeTracker.Entries())
+    {
+      if (entry.Entity is AuditLog || entry.State == EntityState.Unchanged || entry.State == EntityState.Detached)
+        continue;
+
+      var auditLog = new AuditLog
+      {
+        AuditLogId = Guid.NewGuid(),
+        EntityType = entry.Entity.GetType().Name,
+        EntityId = GetEntityId(entry),
+        ChangedBy = userId,
+        ChangedAt = DateTime.UtcNow
+      };
+
+      if (entry.State == EntityState.Added)
+      {
+        auditLog.Action = "Created";
+        auditLog.NewValues = SerializeProperties(entry.CurrentValues);
+      }
+      else if (entry.State == EntityState.Modified)
+      {
+        auditLog.Action = "Updated";
+        auditLog.OldValues = SerializeProperties(entry.OriginalValues);
+        auditLog.NewValues = SerializeProperties(entry.CurrentValues);
+      }
+      else if (entry.State == EntityState.Deleted)
+      {
+        auditLog.Action = "Deleted";
+        auditLog.OldValues = SerializeProperties(entry.OriginalValues);
+      }
+
+      entries.Add(auditLog);
+    }
+
+    return entries;
+  }
+
+  private Guid? GetCurrentUserId()
+  {
+    var claim = _httpContextAccessor?.HttpContext?.User?.FindFirst(ClaimTypes.NameIdentifier)
+                ?? _httpContextAccessor?.HttpContext?.User?.FindFirst("UserId");
+    if (claim != null && Guid.TryParse(claim.Value, out var userId))
+      return userId;
+    return null;
+  }
+
+  private static string GetEntityId(EntityEntry entry)
+  {
+    var keyValues = entry.Metadata.FindPrimaryKey()
+      ?.Properties
+      .Select(p => entry.Property(p.Name).CurrentValue?.ToString() ?? string.Empty)
+      .ToArray();
+    return keyValues != null ? string.Join(",", keyValues) : string.Empty;
+  }
+
+  private static string SerializeProperties(PropertyValues values)
+  {
+    var dict = new Dictionary<string, object?>();
+    foreach (var prop in values.Properties)
+      dict[prop.Name] = values[prop];
+    return JsonSerializer.Serialize(dict);
+  }
 }

--- a/AccountService/src/AccountService/Models/Account.cs
+++ b/AccountService/src/AccountService/Models/Account.cs
@@ -16,4 +16,7 @@ public class Account
   public string? Country { get; set; }
   public DateTime CreatedAt { get; set; }
   public DateTime UpdatedAt { get; set; }
+  public bool IsDeleted { get; set; }
+  public DateTime? DeletedAt { get; set; }
+  public Guid? DeletedBy { get; set; }
 }

--- a/AccountService/src/AccountService/Models/AuditLog.cs
+++ b/AccountService/src/AccountService/Models/AuditLog.cs
@@ -1,0 +1,13 @@
+namespace AccountService.Models;
+
+public class AuditLog
+{
+  public Guid AuditLogId { get; set; }
+  public string EntityType { get; set; } = string.Empty;
+  public string EntityId { get; set; } = string.Empty;
+  public string Action { get; set; } = string.Empty;
+  public string? OldValues { get; set; }
+  public string? NewValues { get; set; }
+  public Guid? ChangedBy { get; set; }
+  public DateTime ChangedAt { get; set; }
+}

--- a/AccountService/src/AccountService/Program.cs
+++ b/AccountService/src/AccountService/Program.cs
@@ -34,6 +34,7 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddDbContext<AccountDbContext>(options =>
   options.UseNpgsql(builder.Configuration.GetConnectionString("AccountDbConnection")));
 
+builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<IAccountRepository, AccountRepository>();
 builder.Services.AddScoped<IAccountService, AccountsService>();
 

--- a/AccountService/src/AccountService/Repository/AccountRepository.cs
+++ b/AccountService/src/AccountService/Repository/AccountRepository.cs
@@ -14,7 +14,7 @@ public class AccountRepository : IAccountRepository
   }
 
   public async Task<Account?> GetByIdAsync(Guid id) =>
-    await _context.Accounts.FindAsync(id);
+    await _context.Accounts.FirstOrDefaultAsync(a => a.AccountId == id);
 
   public async Task<List<Account>> GetAllAsync() =>
     await _context.Accounts.ToListAsync();
@@ -36,7 +36,8 @@ public class AccountRepository : IAccountRepository
     var account = await _context.Accounts.FindAsync(id);
     if (account != null)
     {
-      _context.Accounts.Remove(account);
+      account.IsDeleted = true;
+      account.DeletedAt = DateTime.UtcNow;
       await _context.SaveChangesAsync();
     }
   }

--- a/ActivityService/src/ActivityService.Tests/Repository/ActivityRepositoryTests.cs
+++ b/ActivityService/src/ActivityService.Tests/Repository/ActivityRepositoryTests.cs
@@ -159,7 +159,23 @@ public class ActivityRepositoryTests
   }
 
   [Fact]
-  public async Task DeleteAsync_RemovesActivity()
+  public async Task DeleteAsync_SoftDeletesActivity()
+  {
+    using var context = MakeContext();
+    var repo = new ActivityRepository(context);
+    var activity = MakeActivity();
+    await repo.AddAsync(activity);
+
+    await repo.DeleteAsync(activity.ActivityId);
+
+    var softDeleted = await context.Activities.IgnoreQueryFilters().FirstOrDefaultAsync(a => a.ActivityId == activity.ActivityId);
+    softDeleted.Should().NotBeNull();
+    softDeleted!.IsDeleted.Should().BeTrue();
+    softDeleted.DeletedAt.Should().NotBeNull();
+  }
+
+  [Fact]
+  public async Task DeleteAsync_ExcludesActivityFromQueries()
   {
     using var context = MakeContext();
     var repo = new ActivityRepository(context);
@@ -181,6 +197,21 @@ public class ActivityRepositoryTests
     var act = async () => await repo.DeleteAsync(Guid.NewGuid());
 
     await act.Should().NotThrowAsync();
+  }
+
+  // ── AuditLog ──────────────────────────────────────────────────────────────
+
+  [Fact]
+  public async Task AddAsync_CreatesAuditLogEntry()
+  {
+    using var context = MakeContext();
+    var repo = new ActivityRepository(context);
+    var activity = MakeActivity();
+
+    await repo.AddAsync(activity);
+
+    var auditLogs = await context.AuditLogs.Where(a => a.EntityId == activity.ActivityId.ToString()).ToListAsync();
+    auditLogs.Should().ContainSingle(a => a.Action == "Created");
   }
 
   [Fact]

--- a/ActivityService/src/ActivityService/Data/ActivityDbContext.cs
+++ b/ActivityService/src/ActivityService/Data/ActivityDbContext.cs
@@ -1,11 +1,108 @@
 using ActivityService.Models;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using System.Security.Claims;
+using System.Text.Json;
 
 namespace ActivityService.Data;
 
 public class ActivityDbContext : DbContext
 {
-  public ActivityDbContext(DbContextOptions<ActivityDbContext> options) : base(options) { }
+  private readonly IHttpContextAccessor? _httpContextAccessor;
+
+  public ActivityDbContext(DbContextOptions<ActivityDbContext> options, IHttpContextAccessor? httpContextAccessor = null)
+    : base(options)
+  {
+    _httpContextAccessor = httpContextAccessor;
+  }
 
   public DbSet<Activity> Activities => Set<Activity>();
+  public DbSet<AuditLog> AuditLogs => Set<AuditLog>();
+
+  protected override void OnModelCreating(ModelBuilder modelBuilder)
+  {
+    modelBuilder.Entity<Activity>().HasQueryFilter(a => !a.IsDeleted);
+  }
+
+  public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+  {
+    var auditEntries = BuildAuditEntries();
+    var result = await base.SaveChangesAsync(cancellationToken);
+    if (auditEntries.Count > 0)
+    {
+      AuditLogs.AddRange(auditEntries);
+      await base.SaveChangesAsync(cancellationToken);
+    }
+    return result;
+  }
+
+  private List<AuditLog> BuildAuditEntries()
+  {
+    ChangeTracker.DetectChanges();
+    var userId = GetCurrentUserId();
+    var entries = new List<AuditLog>();
+
+    foreach (var entry in ChangeTracker.Entries())
+    {
+      if (entry.Entity is AuditLog || entry.State == EntityState.Unchanged || entry.State == EntityState.Detached)
+        continue;
+
+      var auditLog = new AuditLog
+      {
+        AuditLogId = Guid.NewGuid(),
+        EntityType = entry.Entity.GetType().Name,
+        EntityId = GetEntityId(entry),
+        ChangedBy = userId,
+        ChangedAt = DateTime.UtcNow
+      };
+
+      if (entry.State == EntityState.Added)
+      {
+        auditLog.Action = "Created";
+        auditLog.NewValues = SerializeProperties(entry.CurrentValues);
+      }
+      else if (entry.State == EntityState.Modified)
+      {
+        auditLog.Action = "Updated";
+        auditLog.OldValues = SerializeProperties(entry.OriginalValues);
+        auditLog.NewValues = SerializeProperties(entry.CurrentValues);
+      }
+      else if (entry.State == EntityState.Deleted)
+      {
+        auditLog.Action = "Deleted";
+        auditLog.OldValues = SerializeProperties(entry.OriginalValues);
+      }
+
+      entries.Add(auditLog);
+    }
+
+    return entries;
+  }
+
+  private Guid? GetCurrentUserId()
+  {
+    var claim = _httpContextAccessor?.HttpContext?.User?.FindFirst(ClaimTypes.NameIdentifier)
+                ?? _httpContextAccessor?.HttpContext?.User?.FindFirst("UserId");
+    if (claim != null && Guid.TryParse(claim.Value, out var userId))
+      return userId;
+    return null;
+  }
+
+  private static string GetEntityId(EntityEntry entry)
+  {
+    var keyValues = entry.Metadata.FindPrimaryKey()
+      ?.Properties
+      .Select(p => entry.Property(p.Name).CurrentValue?.ToString() ?? string.Empty)
+      .ToArray();
+    return keyValues != null ? string.Join(",", keyValues) : string.Empty;
+  }
+
+  private static string SerializeProperties(PropertyValues values)
+  {
+    var dict = new Dictionary<string, object?>();
+    foreach (var prop in values.Properties)
+      dict[prop.Name] = values[prop];
+    return JsonSerializer.Serialize(dict);
+  }
 }

--- a/ActivityService/src/ActivityService/Models/Activity.cs
+++ b/ActivityService/src/ActivityService/Models/Activity.cs
@@ -16,4 +16,7 @@ public class Activity
   public DateTime? CompletedAt { get; set; }
   public DateTime CreatedAt { get; set; }
   public DateTime UpdatedAt { get; set; }
+  public bool IsDeleted { get; set; }
+  public DateTime? DeletedAt { get; set; }
+  public Guid? DeletedBy { get; set; }
 }

--- a/ActivityService/src/ActivityService/Models/AuditLog.cs
+++ b/ActivityService/src/ActivityService/Models/AuditLog.cs
@@ -1,0 +1,13 @@
+namespace ActivityService.Models;
+
+public class AuditLog
+{
+  public Guid AuditLogId { get; set; }
+  public string EntityType { get; set; } = string.Empty;
+  public string EntityId { get; set; } = string.Empty;
+  public string Action { get; set; } = string.Empty;
+  public string? OldValues { get; set; }
+  public string? NewValues { get; set; }
+  public Guid? ChangedBy { get; set; }
+  public DateTime ChangedAt { get; set; }
+}

--- a/ActivityService/src/ActivityService/Program.cs
+++ b/ActivityService/src/ActivityService/Program.cs
@@ -34,6 +34,7 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddDbContext<ActivityDbContext>(options =>
   options.UseNpgsql(builder.Configuration.GetConnectionString("ActivityDbConnection")));
 
+builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<IActivityRepository, ActivityRepository>();
 builder.Services.AddScoped<IActivityService, ActivitiesService>();
 

--- a/ActivityService/src/ActivityService/Repository/ActivityRepository.cs
+++ b/ActivityService/src/ActivityService/Repository/ActivityRepository.cs
@@ -56,7 +56,8 @@ public class ActivityRepository : IActivityRepository
     var activity = await _context.Activities.FindAsync(id);
     if (activity != null)
     {
-      _context.Activities.Remove(activity);
+      activity.IsDeleted = true;
+      activity.DeletedAt = DateTime.UtcNow;
       await _context.SaveChangesAsync();
     }
   }

--- a/ContactService/src/ContactService.Tests/Repository/ContactRepositoryTests.cs
+++ b/ContactService/src/ContactService.Tests/Repository/ContactRepositoryTests.cs
@@ -166,7 +166,7 @@ public class ContactRepositoryTests
   // ── DeleteAsync ───────────────────────────────────────────────────────────
 
   [Fact]
-  public async Task DeleteAsync_RemovesContact()
+  public async Task DeleteAsync_SoftDeletesContact()
   {
     using var ctx = CreateContext();
     var contact = MakeContact();
@@ -176,8 +176,27 @@ public class ContactRepositoryTests
 
     await repo.DeleteAsync(contact.ContactId);
 
-    var deleted = await ctx.Contacts.FindAsync(contact.ContactId);
-    deleted.Should().BeNull();
+    var softDeleted = await ctx.Contacts.IgnoreQueryFilters().FirstOrDefaultAsync(c => c.ContactId == contact.ContactId);
+    softDeleted.Should().NotBeNull();
+    softDeleted!.IsDeleted.Should().BeTrue();
+    softDeleted.DeletedAt.Should().NotBeNull();
+  }
+
+  [Fact]
+  public async Task DeleteAsync_ExcludesContactFromQueries()
+  {
+    using var ctx = CreateContext();
+    var contact = MakeContact();
+    ctx.Contacts.Add(contact);
+    await ctx.SaveChangesAsync();
+    var repo = new ContactRepository(ctx);
+
+    await repo.DeleteAsync(contact.ContactId);
+
+    var found = await repo.GetByIdAsync(contact.ContactId);
+    found.Should().BeNull();
+    var all = await repo.GetAllAsync();
+    all.Should().NotContain(c => c.ContactId == contact.ContactId);
   }
 
   [Fact]
@@ -189,5 +208,20 @@ public class ContactRepositoryTests
     var act = async () => await repo.DeleteAsync(Guid.NewGuid());
 
     await act.Should().NotThrowAsync();
+  }
+
+  // ── AuditLog ──────────────────────────────────────────────────────────────
+
+  [Fact]
+  public async Task AddAsync_CreatesAuditLogEntry()
+  {
+    using var ctx = CreateContext();
+    var repo = new ContactRepository(ctx);
+    var contact = MakeContact();
+
+    await repo.AddAsync(contact);
+
+    var auditLogs = await ctx.AuditLogs.Where(a => a.EntityId == contact.ContactId.ToString()).ToListAsync();
+    auditLogs.Should().ContainSingle(a => a.Action == "Created");
   }
 }

--- a/ContactService/src/ContactService/Data/ContactDbContext.cs
+++ b/ContactService/src/ContactService/Data/ContactDbContext.cs
@@ -1,11 +1,108 @@
 using ContactService.Models;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using System.Security.Claims;
+using System.Text.Json;
 
 namespace ContactService.Data;
 
 public class ContactDbContext : DbContext
 {
-  public ContactDbContext(DbContextOptions<ContactDbContext> options) : base(options) { }
+  private readonly IHttpContextAccessor? _httpContextAccessor;
+
+  public ContactDbContext(DbContextOptions<ContactDbContext> options, IHttpContextAccessor? httpContextAccessor = null)
+    : base(options)
+  {
+    _httpContextAccessor = httpContextAccessor;
+  }
 
   public DbSet<Contact> Contacts => Set<Contact>();
+  public DbSet<AuditLog> AuditLogs => Set<AuditLog>();
+
+  protected override void OnModelCreating(ModelBuilder modelBuilder)
+  {
+    modelBuilder.Entity<Contact>().HasQueryFilter(c => !c.IsDeleted);
+  }
+
+  public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+  {
+    var auditEntries = BuildAuditEntries();
+    var result = await base.SaveChangesAsync(cancellationToken);
+    if (auditEntries.Count > 0)
+    {
+      AuditLogs.AddRange(auditEntries);
+      await base.SaveChangesAsync(cancellationToken);
+    }
+    return result;
+  }
+
+  private List<AuditLog> BuildAuditEntries()
+  {
+    ChangeTracker.DetectChanges();
+    var userId = GetCurrentUserId();
+    var entries = new List<AuditLog>();
+
+    foreach (var entry in ChangeTracker.Entries())
+    {
+      if (entry.Entity is AuditLog || entry.State == EntityState.Unchanged || entry.State == EntityState.Detached)
+        continue;
+
+      var auditLog = new AuditLog
+      {
+        AuditLogId = Guid.NewGuid(),
+        EntityType = entry.Entity.GetType().Name,
+        EntityId = GetEntityId(entry),
+        ChangedBy = userId,
+        ChangedAt = DateTime.UtcNow
+      };
+
+      if (entry.State == EntityState.Added)
+      {
+        auditLog.Action = "Created";
+        auditLog.NewValues = SerializeProperties(entry.CurrentValues);
+      }
+      else if (entry.State == EntityState.Modified)
+      {
+        auditLog.Action = "Updated";
+        auditLog.OldValues = SerializeProperties(entry.OriginalValues);
+        auditLog.NewValues = SerializeProperties(entry.CurrentValues);
+      }
+      else if (entry.State == EntityState.Deleted)
+      {
+        auditLog.Action = "Deleted";
+        auditLog.OldValues = SerializeProperties(entry.OriginalValues);
+      }
+
+      entries.Add(auditLog);
+    }
+
+    return entries;
+  }
+
+  private Guid? GetCurrentUserId()
+  {
+    var claim = _httpContextAccessor?.HttpContext?.User?.FindFirst(ClaimTypes.NameIdentifier)
+                ?? _httpContextAccessor?.HttpContext?.User?.FindFirst("UserId");
+    if (claim != null && Guid.TryParse(claim.Value, out var userId))
+      return userId;
+    return null;
+  }
+
+  private static string GetEntityId(EntityEntry entry)
+  {
+    var keyValues = entry.Metadata.FindPrimaryKey()
+      ?.Properties
+      .Select(p => entry.Property(p.Name).CurrentValue?.ToString() ?? string.Empty)
+      .ToArray();
+    return keyValues != null ? string.Join(",", keyValues) : string.Empty;
+  }
+
+  private static string SerializeProperties(PropertyValues values)
+  {
+    var dict = new Dictionary<string, object?>();
+    foreach (var prop in values.Properties)
+      dict[prop.Name] = values[prop];
+    return JsonSerializer.Serialize(dict);
+  }
 }

--- a/ContactService/src/ContactService/Models/AuditLog.cs
+++ b/ContactService/src/ContactService/Models/AuditLog.cs
@@ -1,0 +1,13 @@
+namespace ContactService.Models;
+
+public class AuditLog
+{
+  public Guid AuditLogId { get; set; }
+  public string EntityType { get; set; } = string.Empty;
+  public string EntityId { get; set; } = string.Empty;
+  public string Action { get; set; } = string.Empty;
+  public string? OldValues { get; set; }
+  public string? NewValues { get; set; }
+  public Guid? ChangedBy { get; set; }
+  public DateTime ChangedAt { get; set; }
+}

--- a/ContactService/src/ContactService/Models/Contact.cs
+++ b/ContactService/src/ContactService/Models/Contact.cs
@@ -14,4 +14,7 @@ public class Contact
   public Guid? OwnerId { get; set; }
   public DateTime CreatedAt { get; set; }
   public DateTime UpdatedAt { get; set; }
+  public bool IsDeleted { get; set; }
+  public DateTime? DeletedAt { get; set; }
+  public Guid? DeletedBy { get; set; }
 }

--- a/ContactService/src/ContactService/Program.cs
+++ b/ContactService/src/ContactService/Program.cs
@@ -34,6 +34,7 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddDbContext<ContactDbContext>(options =>
   options.UseNpgsql(builder.Configuration.GetConnectionString("ContactDbConnection")));
 
+builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<IContactRepository, ContactRepository>();
 builder.Services.AddScoped<IContactService, ContactsService>();
 

--- a/ContactService/src/ContactService/Repository/ContactRepository.cs
+++ b/ContactService/src/ContactService/Repository/ContactRepository.cs
@@ -15,7 +15,7 @@ public class ContactRepository : IContactRepository
   }
 
   public async Task<Contact?> GetByIdAsync(Guid id) =>
-    await _context.Contacts.FindAsync(id);
+    await _context.Contacts.FirstOrDefaultAsync(c => c.ContactId == id);
 
   public async Task<List<Contact>> GetAllAsync(ContactStatus? status = null, Guid? ownerId = null, Guid? accountId = null)
   {
@@ -53,7 +53,8 @@ public class ContactRepository : IContactRepository
     var contact = await _context.Contacts.FindAsync(id);
     if (contact != null)
     {
-      _context.Contacts.Remove(contact);
+      contact.IsDeleted = true;
+      contact.DeletedAt = DateTime.UtcNow;
       await _context.SaveChangesAsync();
     }
   }

--- a/DealService/src/DealService.Tests/Repository/DealRepositoryTests.cs
+++ b/DealService/src/DealService.Tests/Repository/DealRepositoryTests.cs
@@ -166,7 +166,7 @@ public class DealRepositoryTests
   // ── DeleteAsync ───────────────────────────────────────────────────────────
 
   [Fact]
-  public async Task DeleteAsync_RemovesDealFromDb()
+  public async Task DeleteAsync_SoftDeletesDeal()
   {
     using var ctx = CreateContext();
     var deal = MakeDeal();
@@ -176,8 +176,27 @@ public class DealRepositoryTests
 
     await repo.DeleteAsync(deal.DealId);
 
-    var deleted = await ctx.Deals.FindAsync(deal.DealId);
-    deleted.Should().BeNull();
+    var softDeleted = await ctx.Deals.IgnoreQueryFilters().FirstOrDefaultAsync(d => d.DealId == deal.DealId);
+    softDeleted.Should().NotBeNull();
+    softDeleted!.IsDeleted.Should().BeTrue();
+    softDeleted.DeletedAt.Should().NotBeNull();
+  }
+
+  [Fact]
+  public async Task DeleteAsync_ExcludesDealFromQueries()
+  {
+    using var ctx = CreateContext();
+    var deal = MakeDeal();
+    ctx.Deals.Add(deal);
+    await ctx.SaveChangesAsync();
+    var repo = new DealRepository(ctx);
+
+    await repo.DeleteAsync(deal.DealId);
+
+    var found = await repo.GetByIdAsync(deal.DealId);
+    found.Should().BeNull();
+    var all = await repo.GetAllAsync();
+    all.Should().NotContain(d => d.DealId == deal.DealId);
   }
 
   [Fact]
@@ -189,6 +208,21 @@ public class DealRepositoryTests
     var act = async () => await repo.DeleteAsync(Guid.NewGuid());
 
     await act.Should().NotThrowAsync();
+  }
+
+  // ── AuditLog ──────────────────────────────────────────────────────────────
+
+  [Fact]
+  public async Task AddAsync_CreatesAuditLogEntry()
+  {
+    using var ctx = CreateContext();
+    var repo = new DealRepository(ctx);
+    var deal = MakeDeal();
+
+    await repo.AddAsync(deal);
+
+    var auditLogs = await ctx.AuditLogs.Where(a => a.EntityId == deal.DealId.ToString()).ToListAsync();
+    auditLogs.Should().ContainSingle(a => a.Action == "Created");
   }
 
   // ── DealContact operations ─────────────────────────────────────────────────

--- a/DealService/src/DealService/Data/DealDbContext.cs
+++ b/DealService/src/DealService/Data/DealDbContext.cs
@@ -1,14 +1,25 @@
 using DealService.Models;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using System.Security.Claims;
+using System.Text.Json;
 
 namespace DealService.Data;
 
 public class DealDbContext : DbContext
 {
-  public DealDbContext(DbContextOptions<DealDbContext> options) : base(options) { }
+  private readonly IHttpContextAccessor? _httpContextAccessor;
+
+  public DealDbContext(DbContextOptions<DealDbContext> options, IHttpContextAccessor? httpContextAccessor = null)
+    : base(options)
+  {
+    _httpContextAccessor = httpContextAccessor;
+  }
 
   public DbSet<Deal> Deals => Set<Deal>();
   public DbSet<DealContact> DealContacts => Set<DealContact>();
+  public DbSet<AuditLog> AuditLogs => Set<AuditLog>();
 
   protected override void OnModelCreating(ModelBuilder modelBuilder)
   {
@@ -17,5 +28,88 @@ public class DealDbContext : DbContext
       .WithMany(d => d.DealContacts)
       .HasForeignKey(dc => dc.DealId)
       .OnDelete(DeleteBehavior.Cascade);
+
+    modelBuilder.Entity<Deal>().HasQueryFilter(d => !d.IsDeleted);
+  }
+
+  public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+  {
+    var auditEntries = BuildAuditEntries();
+    var result = await base.SaveChangesAsync(cancellationToken);
+    if (auditEntries.Count > 0)
+    {
+      AuditLogs.AddRange(auditEntries);
+      await base.SaveChangesAsync(cancellationToken);
+    }
+    return result;
+  }
+
+  private List<AuditLog> BuildAuditEntries()
+  {
+    ChangeTracker.DetectChanges();
+    var userId = GetCurrentUserId();
+    var entries = new List<AuditLog>();
+
+    foreach (var entry in ChangeTracker.Entries())
+    {
+      if (entry.Entity is AuditLog || entry.State == EntityState.Unchanged || entry.State == EntityState.Detached)
+        continue;
+
+      var auditLog = new AuditLog
+      {
+        AuditLogId = Guid.NewGuid(),
+        EntityType = entry.Entity.GetType().Name,
+        EntityId = GetEntityId(entry),
+        ChangedBy = userId,
+        ChangedAt = DateTime.UtcNow
+      };
+
+      if (entry.State == EntityState.Added)
+      {
+        auditLog.Action = "Created";
+        auditLog.NewValues = SerializeProperties(entry.CurrentValues);
+      }
+      else if (entry.State == EntityState.Modified)
+      {
+        auditLog.Action = "Updated";
+        auditLog.OldValues = SerializeProperties(entry.OriginalValues);
+        auditLog.NewValues = SerializeProperties(entry.CurrentValues);
+      }
+      else if (entry.State == EntityState.Deleted)
+      {
+        auditLog.Action = "Deleted";
+        auditLog.OldValues = SerializeProperties(entry.OriginalValues);
+      }
+
+      entries.Add(auditLog);
+    }
+
+    return entries;
+  }
+
+  private Guid? GetCurrentUserId()
+  {
+    var claim = _httpContextAccessor?.HttpContext?.User?.FindFirst(ClaimTypes.NameIdentifier)
+                ?? _httpContextAccessor?.HttpContext?.User?.FindFirst("UserId");
+    if (claim != null && Guid.TryParse(claim.Value, out var userId))
+      return userId;
+    return null;
+  }
+
+  private static string GetEntityId(EntityEntry entry)
+  {
+    var keyValues = entry.Metadata.FindPrimaryKey()
+      ?.Properties
+      .Select(p => entry.Property(p.Name).CurrentValue?.ToString() ?? string.Empty)
+      .ToArray();
+    return keyValues != null ? string.Join(",", keyValues) : string.Empty;
+  }
+
+  private static string SerializeProperties(PropertyValues values)
+  {
+    var dict = new Dictionary<string, object?>();
+    foreach (var prop in values.Properties)
+      dict[prop.Name] = values[prop];
+    return JsonSerializer.Serialize(dict);
   }
 }

--- a/DealService/src/DealService/Models/AuditLog.cs
+++ b/DealService/src/DealService/Models/AuditLog.cs
@@ -1,0 +1,13 @@
+namespace DealService.Models;
+
+public class AuditLog
+{
+  public Guid AuditLogId { get; set; }
+  public string EntityType { get; set; } = string.Empty;
+  public string EntityId { get; set; } = string.Empty;
+  public string Action { get; set; } = string.Empty;
+  public string? OldValues { get; set; }
+  public string? NewValues { get; set; }
+  public Guid? ChangedBy { get; set; }
+  public DateTime ChangedAt { get; set; }
+}

--- a/DealService/src/DealService/Models/Deal.cs
+++ b/DealService/src/DealService/Models/Deal.cs
@@ -14,5 +14,8 @@ public class Deal
   public Guid? OwnerId { get; set; }
   public DateTime CreatedAt { get; set; }
   public DateTime UpdatedAt { get; set; }
+  public bool IsDeleted { get; set; }
+  public DateTime? DeletedAt { get; set; }
+  public Guid? DeletedBy { get; set; }
   public ICollection<DealContact> DealContacts { get; set; } = new List<DealContact>();
 }

--- a/DealService/src/DealService/Program.cs
+++ b/DealService/src/DealService/Program.cs
@@ -36,6 +36,7 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddDbContext<DealDbContext>(options =>
   options.UseNpgsql(builder.Configuration.GetConnectionString("DealDbConnection")));
 
+builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<IDealRepository, DealRepository>();
 builder.Services.AddScoped<IDealService, DealsService>();
 

--- a/DealService/src/DealService/Repository/DealRepository.cs
+++ b/DealService/src/DealService/Repository/DealRepository.cs
@@ -50,7 +50,8 @@ public class DealRepository : IDealRepository
     var deal = await _context.Deals.FindAsync(id);
     if (deal != null)
     {
-      _context.Deals.Remove(deal);
+      deal.IsDeleted = true;
+      deal.DeletedAt = DateTime.UtcNow;
       await _context.SaveChangesAsync();
     }
   }


### PR DESCRIPTION
Closes #23

Adds soft delete and a lightweight audit trail to all CRM entities.

## Changes
- `IsDeleted`, `DeletedAt`, `DeletedBy` added to Contact, Account, Deal, Activity entities
- `AuditLog` entity per service with EntityType, EntityId, Action, OldValues/NewValues JSON, ChangedBy, ChangedAt
- EF global query filter on each entity to exclude soft-deleted records by default
- `DeleteAsync` in all repositories converted from hard-delete to soft-delete
- `SaveChangesAsync` override in each DbContext auto-generates audit log entries
- `IHttpContextAccessor` used to resolve current user ID from JWT claims
- Repository unit tests updated for soft-delete verification and audit log creation

Generated with [Claude Code](https://claude.ai/code)