### PR TITLE
feat: add E2E test runner script and fix TESTING.md structure

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -413,6 +413,7 @@ EndToEnd.Tests/
     AccountContactFlowTests.cs
     DealFlowTests.cs
     ActivityFlowTests.cs
+    ReportingFlowTests.cs
     GatewayAuthTests.cs
 ```
 
@@ -509,11 +510,21 @@ Gateway health
 
 ### Running E2E tests
 
+The `scripts/run-e2e.sh` script handles the full lifecycle: start the stack, wait for the gateway health check, run the suite, tear down.
+
+```sh
+# Requires Docker and the .NET 9 SDK.
+# Copy .env.example → .env and fill in secrets, or let the script use safe test defaults.
+./scripts/run-e2e.sh
+```
+
+To run steps manually:
+
 ```sh
 # Start the full stack
 docker compose up --build -d
 
-# Wait for gateway health (simple poll script)
+# Wait for gateway health
 until curl -sf http://localhost:5000/health; do sleep 2; done
 
 # Run E2E suite
@@ -523,7 +534,7 @@ dotnet test EndToEnd.Tests/EndToEnd.Tests.csproj
 docker compose down -v
 ```
 
-In CI, add a `test-e2e` job to the GitHub Actions release workflow that runs after the build job.
+In CI, call `scripts/run-e2e.sh` after a build step. All required environment variables have safe defaults so no secrets are needed for a local smoke run.
 
 ---
 

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# run-e2e.sh — Start the Docker Compose stack, run all E2E tests, tear down.
+#
+# Usage:
+#   ./scripts/run-e2e.sh
+#
+# Environment variables (all optional — safe defaults used if absent):
+#   E2E_GATEWAY_URL        Gateway base URL  (default: http://localhost:5000)
+#   E2E_STARTUP_TIMEOUT    Seconds to wait for the gateway health check (default: 120)
+#   JWT_SECRET             (default: a fixed 32-char test secret)
+#   DEFAULT_ADMIN_PASSWORD (default: Admin1234!)
+#   RABBITMQ_USERNAME      (default: guest)
+#   RABBITMQ_PASSWORD      (default: guest)
+#   AUTH_DB_PASSWORD       (default: test-auth-pass)
+#   USER_DB_PASSWORD       (default: test-user-pass)
+#   ACCOUNT_DB_PASSWORD    (default: test-account-pass)
+#   CONTACT_DB_PASSWORD    (default: test-contact-pass)
+#   DEAL_DB_PASSWORD       (default: test-deal-pass)
+#   ACTIVITY_DB_PASSWORD   (default: test-activity-pass)
+#   REPORTING_DB_PASSWORD  (default: test-reporting-pass)
+#
+# In CI, either let the defaults take effect or export variables before
+# calling this script.  A .env file in the repo root is also respected by
+# docker compose when it exists.
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+GATEWAY_URL="${E2E_GATEWAY_URL:-http://localhost:5000}"
+STARTUP_TIMEOUT="${E2E_STARTUP_TIMEOUT:-120}"
+
+# Apply safe test defaults for every variable docker-compose.yml requires,
+# but only when the variable is not already set in the environment.
+export JWT_SECRET="${JWT_SECRET:-e2e-test-secret-minimum-32-characters-ok}"
+export DEFAULT_ADMIN_PASSWORD="${DEFAULT_ADMIN_PASSWORD:-Admin1234!}"
+export RABBITMQ_USERNAME="${RABBITMQ_USERNAME:-guest}"
+export RABBITMQ_PASSWORD="${RABBITMQ_PASSWORD:-guest}"
+export AUTH_DB_PASSWORD="${AUTH_DB_PASSWORD:-test-auth-pass}"
+export USER_DB_PASSWORD="${USER_DB_PASSWORD:-test-user-pass}"
+export ACCOUNT_DB_PASSWORD="${ACCOUNT_DB_PASSWORD:-test-account-pass}"
+export CONTACT_DB_PASSWORD="${CONTACT_DB_PASSWORD:-test-contact-pass}"
+export DEAL_DB_PASSWORD="${DEAL_DB_PASSWORD:-test-deal-pass}"
+export ACTIVITY_DB_PASSWORD="${ACTIVITY_DB_PASSWORD:-test-activity-pass}"
+export REPORTING_DB_PASSWORD="${REPORTING_DB_PASSWORD:-test-reporting-pass}"
+
+# Move to the repository root regardless of where the script is called from.
+cd "$(dirname "$0")/.."
+
+echo "==> Starting Docker Compose stack..."
+docker compose up --build -d
+
+echo "==> Waiting for gateway health check at ${GATEWAY_URL}/health (timeout: ${STARTUP_TIMEOUT}s)..."
+deadline=$((SECONDS + STARTUP_TIMEOUT))
+until curl -sf "${GATEWAY_URL}/health" > /dev/null; do
+  if (( SECONDS > deadline )); then
+    echo "ERROR: Gateway did not become healthy within ${STARTUP_TIMEOUT}s."
+    echo "--- api-gateway logs ---"
+    docker compose logs --tail=50 api-gateway
+    docker compose down -v
+    exit 1
+  fi
+  sleep 2
+done
+echo "==> Gateway is healthy."
+
+echo "==> Running E2E tests..."
+E2E_GATEWAY_URL="${GATEWAY_URL}" dotnet test EndToEnd.Tests/EndToEnd.Tests.csproj --verbosity normal
+TEST_EXIT=$?
+
+echo "==> Tearing down Docker Compose stack..."
+docker compose down -v
+
+exit $TEST_EXIT


### PR DESCRIPTION
Adds `scripts/run-e2e.sh` — a self-contained script that starts the Docker Compose stack, polls the gateway health endpoint, runs the `EndToEnd.Tests` suite, and tears down cleanly. All required env vars have safe test defaults so CI and local smoke runs work without a .env file.

Also fixes the TESTING.md project structure listing to include `ReportingFlowTests.cs`.

Closes #24

Generated with [Claude Code](https://claude.ai/code)