### PR TITLE
feat: add SalesRep and Manager CRM roles (issue #25)

### DIFF
--- a/ApiGateway/src/ApiGateway/Program.cs
+++ b/ApiGateway/src/ApiGateway/Program.cs
@@ -48,6 +48,8 @@ builder.Services
 builder.Services.AddAuthorization(options =>
 {
   options.AddPolicy("admin", policy => policy.RequireRole("Admin"));
+  options.AddPolicy("manager", policy => policy.RequireRole("Manager", "Admin"));
+  options.AddPolicy("salesRep", policy => policy.RequireRole("SalesRep", "Manager", "Admin"));
 });
 
 var rateLimitSettings = builder.Configuration.GetSection("RateLimiting");

--- a/AuthService/src/AuthService.Tests/Services/JwtTokenServiceTests.cs
+++ b/AuthService/src/AuthService.Tests/Services/JwtTokenServiceTests.cs
@@ -38,4 +38,17 @@ public class JwtTokenServiceTests
     Assert.NotNull(token);
     Assert.NotEmpty(token);
   }
+
+  [Theory]
+  [InlineData(UserRole.SalesRep)]
+  [InlineData(UserRole.Manager)]
+  public void GenerateJwtToken_WithCrmRole_ShouldReturnValidToken(UserRole role)
+  {
+    var user = new User { UserId = Guid.NewGuid(), Email = "crm@example.com" };
+
+    var token = _jwtTokenService.GenerateJwtToken(user, role);
+
+    Assert.NotNull(token);
+    Assert.NotEmpty(token);
+  }
 }

--- a/AuthService/src/AuthService/Program.cs
+++ b/AuthService/src/AuthService/Program.cs
@@ -89,6 +89,13 @@ builder.Services.AddAuthentication(options =>
   };
 });
 
+builder.Services.AddAuthorization(options =>
+{
+  options.AddPolicy("admin", policy => policy.RequireRole("Admin"));
+  options.AddPolicy("manager", policy => policy.RequireRole("Manager", "Admin"));
+  options.AddPolicy("salesRep", policy => policy.RequireRole("SalesRep", "Manager", "Admin"));
+});
+
 // Health checks
 builder.Services.AddHealthChecks()
     .AddNpgSql(

--- a/SharedLibrary.Auth/Enums/UserRole.cs
+++ b/SharedLibrary.Auth/Enums/UserRole.cs
@@ -4,5 +4,7 @@ public enum UserRole
 {
   Unassigned,
   Member,
+  SalesRep,
+  Manager,
   Admin
 }

--- a/UserManagementService/src/UserManagementService.Tests/Services/AdminServiceTests.cs
+++ b/UserManagementService/src/UserManagementService.Tests/Services/AdminServiceTests.cs
@@ -72,6 +72,38 @@ public class AdminServiceTests
     result.StatusCode.Should().Be(404);
   }
 
+  [Fact]
+  public async Task UpdateUserRoleAsync_WhenAssigningSalesRep_UpdatesRole()
+  {
+    var userId = Guid.NewGuid();
+    var profile = new UserProfile { UserId = userId, Email = "user@example.com", Role = UserRole.Member, IsActive = true };
+    _mockRepository.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync(profile);
+    _mockRepository.Setup(r => r.UpdateAsync(It.IsAny<UserProfile>())).Returns(Task.CompletedTask);
+
+    var result = await _service.UpdateUserRoleAsync(userId, UserRole.SalesRep);
+
+    result.IsSuccess.Should().BeTrue();
+    result.StatusCode.Should().Be(200);
+    var response = result.Data as AdminUserResponse;
+    response!.Role.Should().Be(UserRole.SalesRep);
+  }
+
+  [Fact]
+  public async Task UpdateUserRoleAsync_WhenAssigningManager_UpdatesRole()
+  {
+    var userId = Guid.NewGuid();
+    var profile = new UserProfile { UserId = userId, Email = "user@example.com", Role = UserRole.SalesRep, IsActive = true };
+    _mockRepository.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync(profile);
+    _mockRepository.Setup(r => r.UpdateAsync(It.IsAny<UserProfile>())).Returns(Task.CompletedTask);
+
+    var result = await _service.UpdateUserRoleAsync(userId, UserRole.Manager);
+
+    result.IsSuccess.Should().BeTrue();
+    result.StatusCode.Should().Be(200);
+    var response = result.Data as AdminUserResponse;
+    response!.Role.Should().Be(UserRole.Manager);
+  }
+
   // ── SetUserActiveAsync ────────────────────────────────────────────────────
 
   [Fact]


### PR DESCRIPTION
Closes #25

Adds `SalesRep` and `Manager` to the `UserRole` enum and wires up authorization policies across ApiGateway and AuthService.

Generated with [Claude Code](https://claude.ai/code)