### PR TITLE
feat: restrict POST /api/registration/register to Admin role only

### DIFF
--- a/AuthService/src/AuthService.Tests/Controllers/RegistrationControllerTests.cs
+++ b/AuthService/src/AuthService.Tests/Controllers/RegistrationControllerTests.cs
@@ -1,5 +1,7 @@
+using System.Reflection;
 using Xunit;
 using Moq;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.Mvc;
 using AuthService.Controllers;
@@ -69,6 +71,20 @@ public class RegistrationControllerTests
     Assert.Equal(409, statusCodeResult.StatusCode);
     Assert.NotNull(statusCodeResult.Value);
     Assert.Contains("Email is already registered.", statusCodeResult.Value.ToString());
+  }
+
+  [Fact]
+  public void Register_ShouldRequireAdminPolicy()
+  {
+    // Verify that the Register action is decorated with [Authorize(Policy = "admin")]
+    // so that only Admin-role JWT holders can provision accounts.
+    var method = typeof(RegistrationController)
+        .GetMethod(nameof(RegistrationController.Register));
+
+    var authorizeAttr = method!.GetCustomAttribute<AuthorizeAttribute>();
+
+    Assert.NotNull(authorizeAttr);
+    Assert.Equal("admin", authorizeAttr.Policy);
   }
 
   [Fact]

--- a/AuthService/src/AuthService/Controllers/RegistrationController.cs
+++ b/AuthService/src/AuthService/Controllers/RegistrationController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using AuthService.Models.DTOs;
 using AuthService.Services;
@@ -19,13 +20,16 @@ public class RegistrationController : ControllerBase
   }
 
   // <summary>
-  // Register a new user
+  // Register a new user (admin only)
   // </summary>
   // <param name="request">RegisterRequest object</param>
   // <returns>RegisterResponse object</returns>
   // <response code="200">User registered successfully</response>
   // <response code="400">Email is already registered</response>
+  // <response code="401">Unauthorized — valid JWT required</response>
+  // <response code="403">Forbidden — Admin role required</response>
   // <response code="500">Internal server error</response>
+  [Authorize(Policy = "admin")]
   [HttpPost("register")]
   public async Task<IActionResult> Register(RegisterRequest request)
   {


### PR DESCRIPTION
Gates public self-registration behind the existing "admin" authorization policy so only users with a valid Admin JWT can provision new accounts.

Closes #26

Generated with [Claude Code](https://claude.ai/code)