### PR TITLE
feat: Unassigned holding state for new users (# 28)

### DIFF
--- a/AuthService/src/AuthService/Program.cs
+++ b/AuthService/src/AuthService/Program.cs
@@ -97,6 +97,8 @@ builder.Services.AddAuthorization(options =>
   options.AddPolicy("admin", policy => policy.RequireRole("Admin"));
   options.AddPolicy("manager", policy => policy.RequireRole("Manager", "Admin"));
   options.AddPolicy("salesRep", policy => policy.RequireRole("SalesRep", "Manager", "Admin"));
+  // Blocks Unassigned users from accessing CRM routes; any promoted role is sufficient
+  options.AddPolicy("member", policy => policy.RequireRole("Member", "SalesRep", "Manager", "Admin"));
 });
 
 // Health checks

--- a/UserManagementService/src/UserManagementService.Tests/Controllers/AdminControllerTests.cs
+++ b/UserManagementService/src/UserManagementService.Tests/Controllers/AdminControllerTests.cs
@@ -88,6 +88,20 @@ public class AdminControllerTests
     obj.StatusCode.Should().Be(500);
   }
 
+  [Fact]
+  public async Task UpdateUserRole_Returns400_WhenRoleIsUnassigned()
+  {
+    var userId = Guid.NewGuid();
+    var request = new UpdateUserRoleRequest { Role = UserRole.Unassigned };
+    _serviceMock.Setup(s => s.UpdateUserRoleAsync(userId, UserRole.Unassigned))
+      .ReturnsAsync(ServiceResult.Failure("Cannot set role to Unassigned."));
+
+    var result = await _sut.UpdateUserRole(userId, request);
+
+    var obj = result.Should().BeOfType<ObjectResult>().Subject;
+    obj.StatusCode.Should().Be(400);
+  }
+
   // ── SetUserActive ─────────────────────────────────────────────────────────
 
   [Fact]

--- a/UserManagementService/src/UserManagementService.Tests/Services/UserProfileServiceTests.cs
+++ b/UserManagementService/src/UserManagementService.Tests/Services/UserProfileServiceTests.cs
@@ -38,7 +38,33 @@ public class UserProfileServiceTests
     var response = result.Data as CreateUserProfileResponse;
     response.Should().NotBeNull();
     response!.UserId.Should().Be(request.UserId);
-    response.Role.Should().Be(UserRole.Member);
+    response.Role.Should().Be(UserRole.Unassigned);
+  }
+
+  [Fact]
+  public async Task UpdateUserRoleAsync_WithUnassignedRole_ReturnsFailure()
+  {
+    var userId = Guid.NewGuid();
+
+    var result = await _service.UpdateUserRoleAsync(userId, UserRole.Unassigned);
+
+    result.IsSuccess.Should().BeFalse();
+    result.StatusCode.Should().Be(400);
+  }
+
+  [Fact]
+  public async Task UpdateUserRoleAsync_PromotesUser_ReturnsSuccess()
+  {
+    var userId = Guid.NewGuid();
+    var profile = new UserProfile { UserId = userId, Email = "user@example.com", Role = UserRole.Unassigned };
+
+    _mockRepository.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync(profile);
+    _mockRepository.Setup(r => r.UpdateAsync(It.IsAny<UserProfile>())).Returns(Task.CompletedTask);
+
+    var result = await _service.UpdateUserRoleAsync(userId, UserRole.Member);
+
+    result.IsSuccess.Should().BeTrue();
+    result.StatusCode.Should().Be(200);
   }
 
   [Fact]

--- a/UserManagementService/src/UserManagementService/Controllers/AdminController.cs
+++ b/UserManagementService/src/UserManagementService/Controllers/AdminController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using UserManagementService.Models.DTOs;
 using UserManagementService.Services;
@@ -6,6 +7,7 @@ namespace UserManagementService.Controllers;
 
 [ApiController]
 [Route("api/admin")]
+[Authorize(Policy = "admin")]
 public class AdminController : ControllerBase
 {
   private readonly IUserProfileService _userProfileService;

--- a/UserManagementService/src/UserManagementService/Program.cs
+++ b/UserManagementService/src/UserManagementService/Program.cs
@@ -1,6 +1,9 @@
 using OpenTelemetry.Exporter;
 using Serilog.Enrichers.OpenTelemetry;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using UserManagementService.Consumers;
 using UserManagementService.Data;
 using UserManagementService.Infrastructure;
@@ -34,6 +37,37 @@ builder.Services.AddDbContext<UserManagementDbContext>(options =>
 
 builder.Services.AddScoped<IUserProfileRepository, UserProfileRepository>();
 builder.Services.AddScoped<IUserProfileService, UserProfileService>();
+
+// Configure JWT authentication (validates tokens issued by AuthService)
+var jwtSettings = builder.Configuration.GetSection("JwtSettings");
+var secretKey = jwtSettings.GetValue<string>("SecretKey") ?? throw new ArgumentNullException("SecretKey", "SecretKey cannot be null");
+
+builder.Services.AddAuthentication(options =>
+{
+  options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+  options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+})
+.AddJwtBearer(options =>
+{
+  options.TokenValidationParameters = new TokenValidationParameters
+  {
+    ValidateIssuer = true,
+    ValidateAudience = true,
+    ValidateLifetime = true,
+    ValidateIssuerSigningKey = true,
+    ValidIssuer = jwtSettings.GetValue<string>("Issuer"),
+    ValidAudience = jwtSettings.GetValue<string>("Audience"),
+    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secretKey))
+  };
+});
+
+builder.Services.AddAuthorization(options =>
+{
+  options.AddPolicy("admin", policy => policy.RequireRole("Admin"));
+  options.AddPolicy("manager", policy => policy.RequireRole("Manager", "Admin"));
+  options.AddPolicy("salesRep", policy => policy.RequireRole("SalesRep", "Manager", "Admin"));
+  options.AddPolicy("member", policy => policy.RequireRole("Member", "SalesRep", "Manager", "Admin"));
+});
 
 // MassTransit + RabbitMQ (consume UserRegistered events)
 builder.Services.AddMassTransit(x =>
@@ -111,6 +145,7 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 app.UseMiddleware<CorrelationIdMiddleware>();
+app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();
 app.MapHealthChecks("/health");

--- a/UserManagementService/src/UserManagementService/Services/UserProfileService.cs
+++ b/UserManagementService/src/UserManagementService/Services/UserProfileService.cs
@@ -25,7 +25,7 @@ public class UserProfileService : IUserProfileService
     {
       UserId = request.UserId,
       Email = request.Email,
-      Role = UserRole.Member,
+      Role = UserRole.Unassigned,
       DisplayName = request.Email,
       CreatedAt = DateTime.UtcNow
     };
@@ -92,6 +92,9 @@ public class UserProfileService : IUserProfileService
 
   public async Task<ServiceResult> UpdateUserRoleAsync(Guid userId, UserRole role)
   {
+    if (role == UserRole.Unassigned)
+      return ServiceResult.Failure("Cannot set role to Unassigned. Use Member, SalesRep, Manager, or Admin.");
+
     var profile = await _repository.GetByIdAsync(userId);
     if (profile == null)
       return ServiceResult.Failure("User profile not found.", 404);

--- a/UserManagementService/src/UserManagementService/appsettings.Development.json
+++ b/UserManagementService/src/UserManagementService/appsettings.Development.json
@@ -8,6 +8,11 @@
   "ConnectionStrings": {
     "UserManagementDbConnection": "Host=localhost;Port=5432;Database=userdb;Username=user_user;Password=user_pass"
   },
+  "JwtSettings": {
+    "SecretKey": "dev-only-secret-key-at-least-32-chars!!",
+    "Issuer": "https://localhost",
+    "Audience": "YourAppUsers"
+  },
   "RabbitMQ": {
     "Host": "localhost",
     "Username": "guest",

--- a/UserManagementService/src/UserManagementService/appsettings.json
+++ b/UserManagementService/src/UserManagementService/appsettings.json
@@ -17,6 +17,11 @@
   "ConnectionStrings": {
     "UserManagementDbConnection": ""
   },
+  "JwtSettings": {
+    "SecretKey": "",
+    "Issuer": "",
+    "Audience": ""
+  },
   "RabbitMQ": {
     "Host": "rabbitmq",
     "VirtualHost": "/",


### PR DESCRIPTION
Implements the Unassigned holding state for new users as described in issue #28.

## Changes
- New users start as `Unassigned` instead of `Member`
- `UpdateUserRoleAsync` rejects `Unassigned` as a target role (400)
- `AdminController` secured with `[Authorize(Policy = "admin")]` — JWT auth added to UserManagementService
- Added "member" policy to AuthService for CRM route protection
- Tests updated

Closes #28

Generated with [Claude Code](https://claude.ai/code)