### PR TITLE
feat: admin user list — complete tests and full role support (#32)

### DIFF
--- a/UserManagementService/src/UserManagementService.IntegrationTests/UserManagementIntegrationTests.cs
+++ b/UserManagementService/src/UserManagementService.IntegrationTests/UserManagementIntegrationTests.cs
@@ -157,6 +157,110 @@ public class UserManagementIntegrationTests : IClassFixture<UserManagementServic
     matching.Should().Be(1);
   }
 
+  // ── GET /api/admin/users ──────────────────────────────────────────────────
+
+  [Fact]
+  public async Task GET_admin_users_Returns401_WithoutAuth()
+  {
+    var response = await _client.GetAsync("/api/admin/users");
+
+    response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+  }
+
+  [Fact]
+  public async Task GET_admin_users_Returns200_WithAdminJwt()
+  {
+    var adminClient = CreateAdminClient();
+
+    var response = await adminClient.GetAsync("/api/admin/users");
+
+    response.StatusCode.Should().Be(HttpStatusCode.OK);
+    var arr = JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement;
+    arr.ValueKind.Should().Be(JsonValueKind.Array);
+  }
+
+  [Fact]
+  public async Task GET_admin_users_ReturnsAllFields()
+  {
+    var userId = Guid.NewGuid();
+    var email = $"admin-list-{Guid.NewGuid()}@test.com";
+    await _client.PostAsJsonAsync("/api/users", new { userId, email, displayName = "List Me" });
+
+    var adminClient = CreateAdminClient();
+    var response = await adminClient.GetAsync("/api/admin/users");
+
+    response.StatusCode.Should().Be(HttpStatusCode.OK);
+    var arr = JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement;
+    var match = arr.EnumerateArray().FirstOrDefault(u => u.GetProperty("userId").GetGuid() == userId);
+    match.ValueKind.Should().NotBe(JsonValueKind.Undefined);
+    match.TryGetProperty("email", out _).Should().BeTrue();
+    match.TryGetProperty("displayName", out _).Should().BeTrue();
+    match.TryGetProperty("role", out _).Should().BeTrue();
+    match.TryGetProperty("isActive", out _).Should().BeTrue();
+  }
+
+  // ── PUT /api/admin/users/{id}/role ────────────────────────────────────────
+
+  [Fact]
+  public async Task PUT_admin_users_role_Returns401_WithoutAuth()
+  {
+    var userId = Guid.NewGuid();
+    var response = await _client.PutAsJsonAsync($"/api/admin/users/{userId}/role", new { role = 1 });
+
+    response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+  }
+
+  [Fact]
+  public async Task PUT_admin_users_role_Returns200_WhenRoleUpdated()
+  {
+    var userId = Guid.NewGuid();
+    await _client.PostAsJsonAsync("/api/users", new { userId, email = $"role-update-{Guid.NewGuid()}@test.com" });
+
+    var adminClient = CreateAdminClient();
+    var response = await adminClient.PutAsJsonAsync($"/api/admin/users/{userId}/role", new { role = 4 }); // Admin
+
+    response.StatusCode.Should().Be(HttpStatusCode.OK);
+    var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+    doc.RootElement.GetProperty("role").GetInt32().Should().Be(4);
+  }
+
+  [Fact]
+  public async Task PUT_admin_users_role_Returns400_WhenRoleIsUnassigned()
+  {
+    var userId = Guid.NewGuid();
+    await _client.PostAsJsonAsync("/api/users", new { userId, email = $"role-unassigned-{Guid.NewGuid()}@test.com" });
+
+    var adminClient = CreateAdminClient();
+    var response = await adminClient.PutAsJsonAsync($"/api/admin/users/{userId}/role", new { role = 0 }); // Unassigned
+
+    response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+  }
+
+  // ── PUT /api/admin/users/{id}/active ─────────────────────────────────────
+
+  [Fact]
+  public async Task PUT_admin_users_active_Returns401_WithoutAuth()
+  {
+    var userId = Guid.NewGuid();
+    var response = await _client.PutAsJsonAsync($"/api/admin/users/{userId}/active", new { isActive = false });
+
+    response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+  }
+
+  [Fact]
+  public async Task PUT_admin_users_active_Returns200_WhenStatusUpdated()
+  {
+    var userId = Guid.NewGuid();
+    await _client.PostAsJsonAsync("/api/users", new { userId, email = $"deactivate-{Guid.NewGuid()}@test.com" });
+
+    var adminClient = CreateAdminClient();
+    var response = await adminClient.PutAsJsonAsync($"/api/admin/users/{userId}/active", new { isActive = false });
+
+    response.StatusCode.Should().Be(HttpStatusCode.OK);
+    var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+    doc.RootElement.GetProperty("isActive").GetBoolean().Should().BeFalse();
+  }
+
   // ── Health ────────────────────────────────────────────────────────────────
 
   [Fact]
@@ -165,5 +269,16 @@ public class UserManagementIntegrationTests : IClassFixture<UserManagementServic
     var response = await _client.GetAsync("/health");
 
     response.StatusCode.Should().Be(HttpStatusCode.OK);
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  private HttpClient CreateAdminClient()
+  {
+    var token = _factory.CreateAdminJwt();
+    var client = _factory.CreateClient();
+    client.DefaultRequestHeaders.Authorization =
+      new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+    return client;
   }
 }

--- a/UserManagementService/src/UserManagementService.IntegrationTests/UserManagementService.IntegrationTests.csproj
+++ b/UserManagementService/src/UserManagementService.IntegrationTests/UserManagementService.IntegrationTests.csproj
@@ -12,7 +12,9 @@
     <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="MassTransit" Version="8.3.6" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.3.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.2" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="3.10.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/UserManagementService/src/UserManagementService.IntegrationTests/UserManagementServiceFactory.cs
+++ b/UserManagementService/src/UserManagementService.IntegrationTests/UserManagementServiceFactory.cs
@@ -3,6 +3,10 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
 using Testcontainers.PostgreSql;
 using UserManagementService.Consumers;
 using UserManagementService.Data;
@@ -13,12 +17,19 @@ public class UserManagementServiceFactory : WebApplicationFactory<Program>, IAsy
 {
   private readonly PostgreSqlContainer _db = new PostgreSqlBuilder().Build();
 
+  public const string TestJwtSecret = "integration-test-secret-key-minimum-32-bytes!";
+  public const string TestJwtIssuer = "test-issuer";
+  public const string TestJwtAudience = "test-audience";
+
   public async Task InitializeAsync() => await _db.StartAsync();
   public new async Task DisposeAsync() => await _db.DisposeAsync();
 
   protected override void ConfigureWebHost(IWebHostBuilder builder)
   {
     builder.UseSetting("ConnectionStrings:UserManagementDbConnection", _db.GetConnectionString());
+    builder.UseSetting("JwtSettings:SecretKey", TestJwtSecret);
+    builder.UseSetting("JwtSettings:Issuer", TestJwtIssuer);
+    builder.UseSetting("JwtSettings:Audience", TestJwtAudience);
 
     builder.ConfigureServices(services =>
     {
@@ -29,5 +40,28 @@ public class UserManagementServiceFactory : WebApplicationFactory<Program>, IAsy
 
       services.AddMassTransitTestHarness(x => x.AddConsumer<UserRegisteredConsumer>());
     });
+  }
+
+  public string CreateAdminJwt(Guid? userId = null)
+  {
+    var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(TestJwtSecret));
+    var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+    var claims = new[]
+    {
+      new Claim(ClaimTypes.Role, "Admin"),
+      new Claim("UserId", (userId ?? Guid.NewGuid()).ToString()),
+      new Claim(JwtRegisteredClaimNames.Sub, "admin@test.com"),
+      new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+    };
+
+    var token = new JwtSecurityToken(
+      issuer: TestJwtIssuer,
+      audience: TestJwtAudience,
+      claims: claims,
+      expires: DateTime.UtcNow.AddHours(1),
+      signingCredentials: credentials);
+
+    return new JwtSecurityTokenHandler().WriteToken(token);
   }
 }

--- a/UserManagementService/src/UserManagementService.Tests/Services/UserProfileServiceTests.cs
+++ b/UserManagementService/src/UserManagementService.Tests/Services/UserProfileServiceTests.cs
@@ -3,6 +3,7 @@ using Moq;
 using SharedLibrary.DTOs;
 using SharedLibrary.Enums;
 using UserManagementService.Models;
+using UserManagementService.Models.DTOs;
 using UserManagementService.Repository;
 using UserManagementService.Services;
 
@@ -103,6 +104,52 @@ public class UserProfileServiceTests
     _mockRepository.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync((UserProfile?)null);
 
     var result = await _service.GetUserProfileAsync(userId);
+
+    result.IsSuccess.Should().BeFalse();
+    result.StatusCode.Should().Be(404);
+  }
+
+  [Fact]
+  public async Task GetAllUsersAsync_ReturnsAllProfiles()
+  {
+    var profiles = new List<UserProfile>
+    {
+      new() { UserId = Guid.NewGuid(), Email = "a@test.com", DisplayName = "A", Role = UserRole.Member, IsActive = true },
+      new() { UserId = Guid.NewGuid(), Email = "b@test.com", DisplayName = "B", Role = UserRole.Admin, IsActive = false },
+    };
+    _mockRepository.Setup(r => r.GetAllAsync()).ReturnsAsync(profiles);
+
+    var result = await _service.GetAllUsersAsync();
+
+    result.IsSuccess.Should().BeTrue();
+    result.StatusCode.Should().Be(200);
+    var users = result.Data as List<AdminUserResponse>;
+    users.Should().HaveCount(2);
+  }
+
+  [Fact]
+  public async Task SetUserActiveAsync_WhenUserFound_TogglesStatus()
+  {
+    var userId = Guid.NewGuid();
+    var profile = new UserProfile { UserId = userId, Email = "user@test.com", Role = UserRole.Member, IsActive = true };
+    _mockRepository.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync(profile);
+    _mockRepository.Setup(r => r.UpdateAsync(It.IsAny<UserProfile>())).Returns(Task.CompletedTask);
+
+    var result = await _service.SetUserActiveAsync(userId, false);
+
+    result.IsSuccess.Should().BeTrue();
+    result.StatusCode.Should().Be(200);
+    var response = result.Data as AdminUserResponse;
+    response!.IsActive.Should().BeFalse();
+  }
+
+  [Fact]
+  public async Task SetUserActiveAsync_WhenUserNotFound_ReturnsFailure()
+  {
+    var userId = Guid.NewGuid();
+    _mockRepository.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync((UserProfile?)null);
+
+    var result = await _service.SetUserActiveAsync(userId, false);
 
     result.IsSuccess.Should().BeFalse();
     result.StatusCode.Should().Be(404);

--- a/frontend/src/pages/admin/AdminUserList.jsx
+++ b/frontend/src/pages/admin/AdminUserList.jsx
@@ -26,10 +26,12 @@ import {
 } from '../../components/ui/dialog.jsx'
 import { EmptyState } from '../../components/EmptyState.jsx'
 
-const ROLES = ['Unassigned', 'Member', 'Admin']
+const ROLES = ['Unassigned', 'Member', 'SalesRep', 'Manager', 'Admin']
 
 const ROLE_VARIANT = {
   Admin: 'default',
+  Manager: 'default',
+  SalesRep: 'secondary',
   Member: 'secondary',
   Unassigned: 'outline',
 }


### PR DESCRIPTION
Completes the admin user list feature from #32.

## Changes
- Frontend: Add SalesRep and Manager to role dropdown and badge variants in AdminUserList
- Unit tests: Add GetAllUsersAsync and SetUserActiveAsync service tests
- Integration tests: Configure JWT factory with CreateAdminJwt() helper
- Integration tests: Add 8 admin endpoint tests (401 without auth, 200 with admin JWT, role/active updates)

Closes #32

Generated with [Claude Code](https://claude.ai/code)