### PR TITLE
feat: Admin deactivate/reactivate user accounts (#034)

### DIFF
--- a/AuthService/src/AuthService.IntegrationTests/AuthIntegrationTests.cs
+++ b/AuthService/src/AuthService.IntegrationTests/AuthIntegrationTests.cs
@@ -26,13 +26,13 @@ public class AuthIntegrationTests : IClassFixture<AuthServiceFactory>
 
   private static readonly Guid AdminId = new("00000000-0000-0000-0000-000000000001");
 
-  private void StubRoleEndpoint(Guid userId, int roleValue = 1) // 1 = Member
+  private void StubRoleEndpoint(Guid userId, int roleValue = 1, bool isActive = true) // 1 = Member
   {
     _factory.UmsMock
       .Given(Request.Create().WithPath($"/api/users/{userId}/role").UsingGet())
       .RespondWith(Response.Create()
         .WithStatusCode(200)
-        .WithBody($"{{\"userId\":\"{userId}\",\"role\":{roleValue}}}")
+        .WithBody($"{{\"userId\":\"{userId}\",\"role\":{roleValue},\"isActive\":{isActive.ToString().ToLower()}}}")
         .WithHeader("Content-Type", "application/json"));
   }
 

--- a/AuthService/src/AuthService.Tests/Services/LoginServiceTests.cs
+++ b/AuthService/src/AuthService.Tests/Services/LoginServiceTests.cs
@@ -43,7 +43,7 @@ public class LoginServiceTests
 
     _mockUserRepository.Setup(r => r.GetUserByEmailAsync(request.Email)).ReturnsAsync(user);
     _mockPasswordService.Setup(p => p.VerifyPassword(request.Password, user.PasswordHash)).Returns(true);
-    _mockUserRoleClient.Setup(r => r.GetRoleAsync(user.UserId)).ReturnsAsync(UserRole.Member);
+    _mockUserRoleClient.Setup(r => r.GetRoleAsync(user.UserId)).ReturnsAsync(new UserRoleResponse { UserId = user.UserId, Role = UserRole.Member, IsActive = true });
     _mockJwtTokenService.Setup(j => j.GenerateJwtToken(user, UserRole.Member)).Returns("jwt-token-string");
     _mockRefreshTokenRepository.Setup(r => r.AddAsync(It.IsAny<RefreshToken>())).Returns(Task.CompletedTask);
 
@@ -128,7 +128,7 @@ public class LoginServiceTests
     _mockRefreshTokenRepository.Setup(r => r.GetByTokenAsync("valid-refresh-token")).ReturnsAsync(existingToken);
     _mockRefreshTokenRepository.Setup(r => r.RevokeAsync(existingToken)).Returns(Task.CompletedTask);
     _mockRefreshTokenRepository.Setup(r => r.AddAsync(It.IsAny<RefreshToken>())).Returns(Task.CompletedTask);
-    _mockUserRoleClient.Setup(r => r.GetRoleAsync(userId)).ReturnsAsync(UserRole.Member);
+    _mockUserRoleClient.Setup(r => r.GetRoleAsync(userId)).ReturnsAsync(new UserRoleResponse { UserId = userId, Role = UserRole.Member, IsActive = true });
     _mockJwtTokenService.Setup(j => j.GenerateJwtToken(user, UserRole.Member)).Returns("new-jwt-token");
 
     // Act
@@ -219,5 +219,57 @@ public class LoginServiceTests
     Assert.False(result.IsSuccess);
     Assert.Equal(401, result.StatusCode);
     Assert.Equal("Invalid or expired refresh token.", result.Message);
+  }
+
+  [Fact]
+  public async Task LoginAsync_ShouldReturnFailure_WhenUserIsDeactivated()
+  {
+    // Arrange
+    var user = new User { UserId = Guid.NewGuid(), Email = "deactivated@example.com", PasswordHash = "hashed" };
+    var request = new LoginRequest { Email = "deactivated@example.com", Password = "SecurePassword123" };
+
+    _mockUserRepository.Setup(r => r.GetUserByEmailAsync(request.Email)).ReturnsAsync(user);
+    _mockPasswordService.Setup(p => p.VerifyPassword(request.Password, user.PasswordHash)).Returns(true);
+    _mockUserRoleClient.Setup(r => r.GetRoleAsync(user.UserId))
+      .ReturnsAsync(new UserRoleResponse { UserId = user.UserId, Role = UserRole.Member, IsActive = false });
+
+    // Act
+    var result = await _service.LoginAsync(request);
+
+    // Assert
+    Assert.False(result.IsSuccess);
+    Assert.Equal(403, result.StatusCode);
+    Assert.Contains("deactivated", result.Message, StringComparison.OrdinalIgnoreCase);
+  }
+
+  [Fact]
+  public async Task RefreshAsync_ShouldReturnFailure_WhenUserIsDeactivated()
+  {
+    // Arrange
+    var userId = Guid.NewGuid();
+    var user = new User { UserId = userId, Email = "deactivated@example.com", PasswordHash = "hashed" };
+    var existingToken = new RefreshToken
+    {
+      Id = Guid.NewGuid(),
+      Token = "valid-refresh-token",
+      UserId = userId,
+      User = user,
+      ExpiresAt = DateTime.UtcNow.AddDays(7),
+      IsRevoked = false
+    };
+    var request = new RefreshRequest { RefreshToken = "valid-refresh-token" };
+
+    _mockRefreshTokenRepository.Setup(r => r.GetByTokenAsync("valid-refresh-token")).ReturnsAsync(existingToken);
+    _mockRefreshTokenRepository.Setup(r => r.RevokeAsync(existingToken)).Returns(Task.CompletedTask);
+    _mockUserRoleClient.Setup(r => r.GetRoleAsync(userId))
+      .ReturnsAsync(new UserRoleResponse { UserId = userId, Role = UserRole.Member, IsActive = false });
+
+    // Act
+    var result = await _service.RefreshAsync(request);
+
+    // Assert
+    Assert.False(result.IsSuccess);
+    Assert.Equal(403, result.StatusCode);
+    Assert.Contains("deactivated", result.Message, StringComparison.OrdinalIgnoreCase);
   }
 }

--- a/AuthService/src/AuthService.Tests/Services/UserRoleClientTests.cs
+++ b/AuthService/src/AuthService.Tests/Services/UserRoleClientTests.cs
@@ -1,3 +1,4 @@
+using AuthService.Models.DTOs;
 using AuthService.Services;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
@@ -24,7 +25,7 @@ public class UserRoleClientTests
   public async Task GetRoleAsync_ReturnsRole_OnSuccessResponse()
   {
     var userId = Guid.NewGuid();
-    var payload = JsonSerializer.Serialize(new { userId, role = (int)UserRole.Member });
+    var payload = JsonSerializer.Serialize(new { userId, role = (int)UserRole.Member, isActive = true });
 
     var handler = new MockHttpMessageHandler();
     handler.When($"/api/users/{userId}/role")
@@ -34,14 +35,15 @@ public class UserRoleClientTests
 
     var result = await sut.GetRoleAsync(userId);
 
-    result.Should().Be(UserRole.Member);
+    result.Role.Should().Be(UserRole.Member);
+    result.IsActive.Should().BeTrue();
   }
 
   [Fact]
   public async Task GetRoleAsync_ReturnsAdminRole_WhenResponseContainsAdmin()
   {
     var userId = Guid.NewGuid();
-    var payload = JsonSerializer.Serialize(new { userId, role = (int)UserRole.Admin });
+    var payload = JsonSerializer.Serialize(new { userId, role = (int)UserRole.Admin, isActive = true });
 
     var handler = new MockHttpMessageHandler();
     handler.When($"/api/users/{userId}/role")
@@ -51,11 +53,30 @@ public class UserRoleClientTests
 
     var result = await sut.GetRoleAsync(userId);
 
-    result.Should().Be(UserRole.Admin);
+    result.Role.Should().Be(UserRole.Admin);
+    result.IsActive.Should().BeTrue();
   }
 
   [Fact]
-  public async Task GetRoleAsync_ReturnsUnassigned_WhenResponseIsNotSuccess()
+  public async Task GetRoleAsync_ReturnsIsActiveFalse_WhenUserIsDeactivated()
+  {
+    var userId = Guid.NewGuid();
+    var payload = JsonSerializer.Serialize(new { userId, role = (int)UserRole.Member, isActive = false });
+
+    var handler = new MockHttpMessageHandler();
+    handler.When($"/api/users/{userId}/role")
+      .Respond("application/json", payload);
+
+    var sut = new UserRoleClient(BuildClient(handler), Logger());
+
+    var result = await sut.GetRoleAsync(userId);
+
+    result.Role.Should().Be(UserRole.Member);
+    result.IsActive.Should().BeFalse();
+  }
+
+  [Fact]
+  public async Task GetRoleAsync_ReturnsUnassignedAndActive_WhenResponseIsNotSuccess()
   {
     var userId = Guid.NewGuid();
 
@@ -67,11 +88,12 @@ public class UserRoleClientTests
 
     var result = await sut.GetRoleAsync(userId);
 
-    result.Should().Be(UserRole.Unassigned);
+    result.Role.Should().Be(UserRole.Unassigned);
+    result.IsActive.Should().BeTrue();
   }
 
   [Fact]
-  public async Task GetRoleAsync_ReturnsUnassigned_OnNetworkException()
+  public async Task GetRoleAsync_ReturnsUnassignedAndActive_OnNetworkException()
   {
     var userId = Guid.NewGuid();
 
@@ -83,6 +105,7 @@ public class UserRoleClientTests
 
     var result = await sut.GetRoleAsync(userId);
 
-    result.Should().Be(UserRole.Unassigned);
+    result.Role.Should().Be(UserRole.Unassigned);
+    result.IsActive.Should().BeTrue();
   }
 }

--- a/AuthService/src/AuthService/Models/DTOs/UserRoleResponse.cs
+++ b/AuthService/src/AuthService/Models/DTOs/UserRoleResponse.cs
@@ -6,4 +6,5 @@ public class UserRoleResponse
 {
   public Guid UserId { get; set; }
   public UserRole Role { get; set; }
+  public bool IsActive { get; set; }
 }

--- a/AuthService/src/AuthService/Services/IUserRoleClient.cs
+++ b/AuthService/src/AuthService/Services/IUserRoleClient.cs
@@ -1,8 +1,8 @@
-using SharedLibrary.Enums;
+using AuthService.Models.DTOs;
 
 namespace AuthService.Services;
 
 public interface IUserRoleClient
 {
-  Task<UserRole> GetRoleAsync(Guid userId);
+  Task<UserRoleResponse> GetRoleAsync(Guid userId);
 }

--- a/AuthService/src/AuthService/Services/LoginService.cs
+++ b/AuthService/src/AuthService/Services/LoginService.cs
@@ -53,8 +53,14 @@ public class LoginService : ILoginService
       return ServiceResult.Failure("Invalid email or password.", 401);
     }
 
-    var role = await _userRoleClient.GetRoleAsync(user.UserId);
-    var jwtToken = _jwtTokenService.GenerateJwtToken(user, role);
+    var userStatus = await _userRoleClient.GetRoleAsync(user.UserId);
+    if (!userStatus.IsActive)
+    {
+      _logger.LogWarning("Login failed: User with email {Email} is deactivated.", request.Email);
+      return ServiceResult.Failure("Account is deactivated. Please contact an administrator.", 403);
+    }
+
+    var jwtToken = _jwtTokenService.GenerateJwtToken(user, userStatus.Role);
     var refreshToken = await CreateRefreshTokenAsync(user.UserId);
 
     _logger.LogInformation("User with email {Email} logged in successfully.", request.Email);
@@ -78,8 +84,14 @@ public class LoginService : ILoginService
 
     await _refreshTokenRepository.RevokeAsync(existing);
 
-    var role = await _userRoleClient.GetRoleAsync(existing.UserId);
-    var newJwt = _jwtTokenService.GenerateJwtToken(existing.User, role);
+    var userStatus = await _userRoleClient.GetRoleAsync(existing.UserId);
+    if (!userStatus.IsActive)
+    {
+      _logger.LogWarning("Refresh failed: User {UserId} is deactivated.", existing.UserId);
+      return ServiceResult.Failure("Account is deactivated.", 403);
+    }
+
+    var newJwt = _jwtTokenService.GenerateJwtToken(existing.User, userStatus.Role);
     var newRefreshToken = await CreateRefreshTokenAsync(existing.UserId);
 
     _logger.LogInformation("Refresh token rotated for user {UserId}.", existing.UserId);

--- a/AuthService/src/AuthService/Services/UserRoleClient.cs
+++ b/AuthService/src/AuthService/Services/UserRoleClient.cs
@@ -15,23 +15,24 @@ public class UserRoleClient : IUserRoleClient
     _logger = logger;
   }
 
-  public async Task<UserRole> GetRoleAsync(Guid userId)
+  public async Task<UserRoleResponse> GetRoleAsync(Guid userId)
   {
+    var fallback = new UserRoleResponse { UserId = userId, Role = UserRole.Unassigned, IsActive = true };
     try
     {
       var response = await _httpClient.GetAsync($"/api/users/{userId}/role");
       if (!response.IsSuccessStatusCode)
       {
         _logger.LogWarning("Failed to fetch role for user {UserId}, defaulting to Unassigned", userId);
-        return UserRole.Unassigned;
+        return fallback;
       }
       var result = await response.Content.ReadFromJsonAsync<UserRoleResponse>();
-      return result?.Role ?? UserRole.Unassigned;
+      return result ?? fallback;
     }
     catch (Exception ex)
     {
       _logger.LogError(ex, "Error fetching role for user {UserId}, defaulting to Unassigned", userId);
-      return UserRole.Unassigned;
+      return fallback;
     }
   }
 }

--- a/UserManagementService/src/UserManagementService.Tests/Controllers/UsersControllerTests.cs
+++ b/UserManagementService/src/UserManagementService.Tests/Controllers/UsersControllerTests.cs
@@ -162,6 +162,63 @@ public class UsersControllerTests
     obj.StatusCode.Should().Be(404);
   }
 
+  // ── PatchUserStatus ───────────────────────────────────────────────────────
+
+  [Fact]
+  public async Task PatchUserStatus_ReturnsOk_WhenDeactivatingUser()
+  {
+    var userId = Guid.NewGuid();
+    var request = new SetUserActiveRequest { IsActive = false };
+    _serviceMock.Setup(s => s.SetUserActiveAsync(userId, false))
+      .ReturnsAsync(ServiceResult.Success(new AdminUserResponse { UserId = userId, IsActive = false }));
+
+    var result = await _sut.PatchUserStatus(userId, request);
+
+    var obj = result.Should().BeOfType<ObjectResult>().Subject;
+    obj.StatusCode.Should().Be(200);
+  }
+
+  [Fact]
+  public async Task PatchUserStatus_ReturnsOk_WhenReactivatingUser()
+  {
+    var userId = Guid.NewGuid();
+    var request = new SetUserActiveRequest { IsActive = true };
+    _serviceMock.Setup(s => s.SetUserActiveAsync(userId, true))
+      .ReturnsAsync(ServiceResult.Success(new AdminUserResponse { UserId = userId, IsActive = true }));
+
+    var result = await _sut.PatchUserStatus(userId, request);
+
+    var obj = result.Should().BeOfType<ObjectResult>().Subject;
+    obj.StatusCode.Should().Be(200);
+  }
+
+  [Fact]
+  public async Task PatchUserStatus_Returns404_WhenUserNotFound()
+  {
+    var userId = Guid.NewGuid();
+    var request = new SetUserActiveRequest { IsActive = false };
+    _serviceMock.Setup(s => s.SetUserActiveAsync(userId, false))
+      .ReturnsAsync(ServiceResult.Failure("User profile not found.", 404));
+
+    var result = await _sut.PatchUserStatus(userId, request);
+
+    var obj = result.Should().BeOfType<ObjectResult>().Subject;
+    obj.StatusCode.Should().Be(404);
+  }
+
+  [Fact]
+  public async Task PatchUserStatus_Returns500_OnException()
+  {
+    var userId = Guid.NewGuid();
+    var request = new SetUserActiveRequest { IsActive = false };
+    _serviceMock.Setup(s => s.SetUserActiveAsync(userId, false)).ThrowsAsync(new Exception());
+
+    var result = await _sut.PatchUserStatus(userId, request);
+
+    var obj = result.Should().BeOfType<ObjectResult>().Subject;
+    obj.StatusCode.Should().Be(500);
+  }
+
   // ── PatchUserRole ─────────────────────────────────────────────────────────
 
   [Fact]

--- a/UserManagementService/src/UserManagementService/Controllers/UsersController.cs
+++ b/UserManagementService/src/UserManagementService/Controllers/UsersController.cs
@@ -83,6 +83,22 @@ public class UsersController : ControllerBase
     }
   }
 
+  [HttpPatch("{userId:guid}/status")]
+  [Authorize(Policy = "admin")]
+  public async Task<IActionResult> PatchUserStatus(Guid userId, [FromBody] SetUserActiveRequest request)
+  {
+    try
+    {
+      var result = await _userProfileService.SetUserActiveAsync(userId, request.IsActive);
+      return StatusCode(result.StatusCode, result.Data ?? result.Message);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Error updating status for user {UserId}", userId);
+      return StatusCode(500, "An error occurred while updating the user status.");
+    }
+  }
+
   [HttpPatch("{userId:guid}/role")]
   [Authorize(Policy = "admin")]
   public async Task<IActionResult> PatchUserRole(Guid userId, [FromBody] UpdateUserRoleRequest request)

--- a/UserManagementService/src/UserManagementService/Models/DTOs/UserRoleResponse.cs
+++ b/UserManagementService/src/UserManagementService/Models/DTOs/UserRoleResponse.cs
@@ -6,4 +6,5 @@ public class UserRoleResponse
 {
   public Guid UserId { get; set; }
   public UserRole Role { get; set; }
+  public bool IsActive { get; set; }
 }

--- a/UserManagementService/src/UserManagementService/Services/UserProfileService.cs
+++ b/UserManagementService/src/UserManagementService/Services/UserProfileService.cs
@@ -57,7 +57,8 @@ public class UserProfileService : IUserProfileService
     return ServiceResult.Success(new UserRoleResponse
     {
       UserId = profile.UserId,
-      Role = profile.Role
+      Role = profile.Role,
+      IsActive = profile.IsActive
     });
   }
 


### PR DESCRIPTION
Closes #34

## Summary
- Add `PATCH /api/users/{id}/status` (Admin only) to deactivate/reactivate accounts (soft-delete)
- Extend `UserRoleResponse` with `IsActive` so the existing login-time role fetch also returns account status in one call
- LoginService enforces deactivation at login and token-refresh with 403

## Test plan
- [x] Unit tests for `PatchUserStatus` controller (deactivate, reactivate, 404, 500)
- [x] Unit tests for deactivated-user login and refresh rejection
- [x] Updated `UserRoleClientTests` to assert `IsActive`
- [x] Integration test WireMock stubs updated to include `isActive`

Generated with [Claude Code](https://claude.ai/code)