### PR TITLE
feat: admin resend invite to pending users

### DIFF
--- a/UserManagementService/src/UserManagementService.Tests/Controllers/UsersControllerTests.cs
+++ b/UserManagementService/src/UserManagementService.Tests/Controllers/UsersControllerTests.cs
@@ -286,4 +286,57 @@ public class UsersControllerTests
     var obj = result.Should().BeOfType<ObjectResult>().Subject;
     obj.StatusCode.Should().Be(500);
   }
+
+  // ── ResendInvite ──────────────────────────────────────────────────────────
+
+  [Fact]
+  public async Task ResendInvite_ReturnsOk_WhenSuccessful()
+  {
+    var userId = Guid.NewGuid();
+    _serviceMock.Setup(s => s.ResendInviteAsync(userId))
+      .ReturnsAsync(ServiceResult.Success(new { userId, email = "user@example.com" }));
+
+    var result = await _sut.ResendInvite(userId);
+
+    var obj = result.Should().BeOfType<ObjectResult>().Subject;
+    obj.StatusCode.Should().Be(200);
+  }
+
+  [Fact]
+  public async Task ResendInvite_Returns404_WhenUserNotFound()
+  {
+    var userId = Guid.NewGuid();
+    _serviceMock.Setup(s => s.ResendInviteAsync(userId))
+      .ReturnsAsync(ServiceResult.Failure("User profile not found.", 404));
+
+    var result = await _sut.ResendInvite(userId);
+
+    var obj = result.Should().BeOfType<ObjectResult>().Subject;
+    obj.StatusCode.Should().Be(404);
+  }
+
+  [Fact]
+  public async Task ResendInvite_Returns400_WhenNoPendingInvite()
+  {
+    var userId = Guid.NewGuid();
+    _serviceMock.Setup(s => s.ResendInviteAsync(userId))
+      .ReturnsAsync(ServiceResult.Failure("User does not have a pending invite."));
+
+    var result = await _sut.ResendInvite(userId);
+
+    var obj = result.Should().BeOfType<ObjectResult>().Subject;
+    obj.StatusCode.Should().Be(400);
+  }
+
+  [Fact]
+  public async Task ResendInvite_Returns500_OnException()
+  {
+    var userId = Guid.NewGuid();
+    _serviceMock.Setup(s => s.ResendInviteAsync(userId)).ThrowsAsync(new Exception());
+
+    var result = await _sut.ResendInvite(userId);
+
+    var obj = result.Should().BeOfType<ObjectResult>().Subject;
+    obj.StatusCode.Should().Be(500);
+  }
 }

--- a/UserManagementService/src/UserManagementService.Tests/Services/AdminServiceTests.cs
+++ b/UserManagementService/src/UserManagementService.Tests/Services/AdminServiceTests.cs
@@ -11,12 +11,16 @@ namespace UserManagementService.Tests.Services;
 public class AdminServiceTests
 {
   private readonly Mock<IUserProfileRepository> _mockRepository;
+  private readonly Mock<IEmailService> _mockEmailService;
   private readonly UserProfileService _service;
 
   public AdminServiceTests()
   {
     _mockRepository = new Mock<IUserProfileRepository>();
-    _service = new UserProfileService(_mockRepository.Object);
+    _mockEmailService = new Mock<IEmailService>();
+    _mockEmailService.Setup(e => e.SendInviteEmailAsync(It.IsAny<string>(), It.IsAny<string>()))
+      .Returns(Task.CompletedTask);
+    _service = new UserProfileService(_mockRepository.Object, _mockEmailService.Object);
   }
 
   // ── GetAllUsersAsync ──────────────────────────────────────────────────────

--- a/UserManagementService/src/UserManagementService.Tests/Services/UserProfileServiceTests.cs
+++ b/UserManagementService/src/UserManagementService.Tests/Services/UserProfileServiceTests.cs
@@ -12,12 +12,16 @@ namespace UserManagementService.Tests.Services;
 public class UserProfileServiceTests
 {
   private readonly Mock<IUserProfileRepository> _mockRepository;
+  private readonly Mock<IEmailService> _mockEmailService;
   private readonly UserProfileService _service;
 
   public UserProfileServiceTests()
   {
     _mockRepository = new Mock<IUserProfileRepository>();
-    _service = new UserProfileService(_mockRepository.Object);
+    _mockEmailService = new Mock<IEmailService>();
+    _mockEmailService.Setup(e => e.SendInviteEmailAsync(It.IsAny<string>(), It.IsAny<string>()))
+      .Returns(Task.CompletedTask);
+    _service = new UserProfileService(_mockRepository.Object, _mockEmailService.Object);
   }
 
   [Fact]
@@ -153,5 +157,81 @@ public class UserProfileServiceTests
 
     result.IsSuccess.Should().BeFalse();
     result.StatusCode.Should().Be(404);
+  }
+
+  // ── ResendInviteAsync ────────────────────────────────────────────────────
+
+  [Fact]
+  public async Task ResendInviteAsync_WhenUserNotFound_ReturnsFailure()
+  {
+    var userId = Guid.NewGuid();
+    _mockRepository.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync((UserProfile?)null);
+
+    var result = await _service.ResendInviteAsync(userId);
+
+    result.IsSuccess.Should().BeFalse();
+    result.StatusCode.Should().Be(404);
+  }
+
+  [Fact]
+  public async Task ResendInviteAsync_WhenNoPendingInvite_ReturnsFailure()
+  {
+    var userId = Guid.NewGuid();
+    var profile = new UserProfile { UserId = userId, Email = "user@example.com", InviteToken = null };
+    _mockRepository.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync(profile);
+
+    var result = await _service.ResendInviteAsync(userId);
+
+    result.IsSuccess.Should().BeFalse();
+    result.StatusCode.Should().Be(400);
+    result.Message.Should().Contain("pending invite");
+  }
+
+  [Fact]
+  public async Task ResendInviteAsync_WithPendingInvite_RegeneratesTokenAndSendsEmail()
+  {
+    var userId = Guid.NewGuid();
+    var profile = new UserProfile
+    {
+      UserId = userId,
+      Email = "user@example.com",
+      InviteToken = "old-token",
+      InvitePendingAt = DateTime.UtcNow.AddDays(-3)
+    };
+    _mockRepository.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync(profile);
+    _mockRepository.Setup(r => r.UpdateAsync(It.IsAny<UserProfile>())).Returns(Task.CompletedTask);
+
+    var result = await _service.ResendInviteAsync(userId);
+
+    result.IsSuccess.Should().BeTrue();
+    result.StatusCode.Should().Be(200);
+    var response = result.Data as ResendInviteResponse;
+    response.Should().NotBeNull();
+    response!.UserId.Should().Be(userId);
+    response.Email.Should().Be("user@example.com");
+    profile.InviteToken.Should().NotBe("old-token");
+    _mockEmailService.Verify(e => e.SendInviteEmailAsync("user@example.com", profile.InviteToken!), Times.Once);
+  }
+
+  [Fact]
+  public async Task ResendInviteAsync_WithPendingInvite_UpdatesInvitePendingAt()
+  {
+    var userId = Guid.NewGuid();
+    var originalTime = DateTime.UtcNow.AddDays(-3);
+    var profile = new UserProfile
+    {
+      UserId = userId,
+      Email = "user@example.com",
+      InviteToken = "old-token",
+      InvitePendingAt = originalTime
+    };
+    _mockRepository.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync(profile);
+    _mockRepository.Setup(r => r.UpdateAsync(It.IsAny<UserProfile>())).Returns(Task.CompletedTask);
+
+    var before = DateTime.UtcNow;
+    await _service.ResendInviteAsync(userId);
+
+    profile.InvitePendingAt.Should().NotBeNull();
+    profile.InvitePendingAt!.Value.Should().BeOnOrAfter(before);
   }
 }

--- a/UserManagementService/src/UserManagementService/Controllers/UsersController.cs
+++ b/UserManagementService/src/UserManagementService/Controllers/UsersController.cs
@@ -117,4 +117,20 @@ public class UsersController : ControllerBase
       return StatusCode(500, "An error occurred while updating the user role.");
     }
   }
+
+  [HttpPost("{userId:guid}/resend-invite")]
+  [Authorize(Policy = "admin")]
+  public async Task<IActionResult> ResendInvite(Guid userId)
+  {
+    try
+    {
+      var result = await _userProfileService.ResendInviteAsync(userId);
+      return StatusCode(result.StatusCode, result.Data ?? result.Message);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Error resending invite for user {UserId}", userId);
+      return StatusCode(500, "An error occurred while resending the invite.");
+    }
+  }
 }

--- a/UserManagementService/src/UserManagementService/Models/DTOs/ResendInviteResponse.cs
+++ b/UserManagementService/src/UserManagementService/Models/DTOs/ResendInviteResponse.cs
@@ -1,0 +1,8 @@
+namespace UserManagementService.Models.DTOs;
+
+public class ResendInviteResponse
+{
+  public Guid UserId { get; set; }
+  public string Email { get; set; } = string.Empty;
+  public DateTime InviteSentAt { get; set; }
+}

--- a/UserManagementService/src/UserManagementService/Models/UserProfile.cs
+++ b/UserManagementService/src/UserManagementService/Models/UserProfile.cs
@@ -20,4 +20,8 @@ public class UserProfile
   public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
   public bool IsActive { get; set; } = true;
+
+  public string? InviteToken { get; set; }
+
+  public DateTime? InvitePendingAt { get; set; }
 }

--- a/UserManagementService/src/UserManagementService/Program.cs
+++ b/UserManagementService/src/UserManagementService/Program.cs
@@ -37,6 +37,7 @@ builder.Services.AddDbContext<UserManagementDbContext>(options =>
 
 builder.Services.AddScoped<IUserProfileRepository, UserProfileRepository>();
 builder.Services.AddScoped<IUserProfileService, UserProfileService>();
+builder.Services.AddSingleton<IEmailService, EmailService>();
 
 // Configure JWT authentication (validates tokens issued by AuthService)
 var jwtSettings = builder.Configuration.GetSection("JwtSettings");

--- a/UserManagementService/src/UserManagementService/Services/EmailService.cs
+++ b/UserManagementService/src/UserManagementService/Services/EmailService.cs
@@ -1,0 +1,18 @@
+namespace UserManagementService.Services;
+
+public class EmailService : IEmailService
+{
+  private readonly ILogger<EmailService> _logger;
+
+  public EmailService(ILogger<EmailService> logger)
+  {
+    _logger = logger;
+  }
+
+  public Task SendInviteEmailAsync(string email, string inviteToken)
+  {
+    // Stub: log instead of sending a real email until an email provider is configured.
+    _logger.LogInformation("Invite email queued for {Email} with token {InviteToken}", email, inviteToken);
+    return Task.CompletedTask;
+  }
+}

--- a/UserManagementService/src/UserManagementService/Services/IEmailService.cs
+++ b/UserManagementService/src/UserManagementService/Services/IEmailService.cs
@@ -1,0 +1,6 @@
+namespace UserManagementService.Services;
+
+public interface IEmailService
+{
+  Task SendInviteEmailAsync(string email, string inviteToken);
+}

--- a/UserManagementService/src/UserManagementService/Services/IUserProfileService.cs
+++ b/UserManagementService/src/UserManagementService/Services/IUserProfileService.cs
@@ -12,4 +12,5 @@ public interface IUserProfileService
   Task<ServiceResult> GetAllUsersAsync();
   Task<ServiceResult> UpdateUserRoleAsync(Guid userId, UserRole role);
   Task<ServiceResult> SetUserActiveAsync(Guid userId, bool isActive);
+  Task<ServiceResult> ResendInviteAsync(Guid userId);
 }

--- a/UserManagementService/src/UserManagementService/Services/UserProfileService.cs
+++ b/UserManagementService/src/UserManagementService/Services/UserProfileService.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using SharedLibrary.DTOs;
 using SharedLibrary.Enums;
 using UserManagementService.Models;
@@ -9,10 +10,12 @@ namespace UserManagementService.Services;
 public class UserProfileService : IUserProfileService
 {
   private readonly IUserProfileRepository _repository;
+  private readonly IEmailService _emailService;
 
-  public UserProfileService(IUserProfileRepository repository)
+  public UserProfileService(IUserProfileRepository repository, IEmailService emailService)
   {
     _repository = repository;
+    _emailService = emailService;
   }
 
   public async Task<ServiceResult> CreateUserProfileAsync(CreateUserProfileRequest request)
@@ -131,6 +134,30 @@ public class UserProfileService : IUserProfileService
       Role = profile.Role,
       IsActive = profile.IsActive,
       CreatedAt = profile.CreatedAt
+    });
+  }
+
+  public async Task<ServiceResult> ResendInviteAsync(Guid userId)
+  {
+    var profile = await _repository.GetByIdAsync(userId);
+    if (profile == null)
+      return ServiceResult.Failure("User profile not found.", 404);
+
+    if (profile.InviteToken == null)
+      return ServiceResult.Failure("User does not have a pending invite.");
+
+    var newToken = Convert.ToHexString(RandomNumberGenerator.GetBytes(32)).ToLowerInvariant();
+    profile.InviteToken = newToken;
+    profile.InvitePendingAt = DateTime.UtcNow;
+    await _repository.UpdateAsync(profile);
+
+    await _emailService.SendInviteEmailAsync(profile.Email, newToken);
+
+    return ServiceResult.Success(new ResendInviteResponse
+    {
+      UserId = profile.UserId,
+      Email = profile.Email,
+      InviteSentAt = profile.InvitePendingAt.Value
     });
   }
 }


### PR DESCRIPTION
Implements `POST /api/users/{id}/resend-invite` (Admin only) as described in issue #35.

Regenerates a cryptographically secure invite token, invalidates the previous one, updates `InvitePendingAt`, and sends an invite email via a new `IEmailService` abstraction (stub logs until a real email provider is wired in).

Closes #35

Generated with [Claude Code](https://claude.ai/code)