### PR TITLE
feat: add MailKit and implement SMTP-backed EmailService

### DIFF
--- a/AuthService/src/AuthService.Tests/Services/EmailServiceTests.cs
+++ b/AuthService/src/AuthService.Tests/Services/EmailServiceTests.cs
@@ -1,0 +1,65 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using AuthService.Services;
+
+public class EmailServiceTests
+{
+  private static EmailService CreateService(Dictionary<string, string?> config)
+  {
+    var logger = new Mock<ILogger<EmailService>>().Object;
+    var configuration = new ConfigurationBuilder()
+        .AddInMemoryCollection(config)
+        .Build();
+    return new EmailService(logger, configuration);
+  }
+
+  [Fact]
+  public async Task SendInviteEmailAsync_WhenNoSmtpHostConfigured_LogsDevStubAndReturns()
+  {
+    var mockLogger = new Mock<ILogger<EmailService>>();
+    var configuration = new ConfigurationBuilder()
+        .AddInMemoryCollection(new Dictionary<string, string?>
+        {
+          ["InviteSettings:FrontendUrl"] = "http://localhost:3000",
+          ["Smtp:Host"] = ""
+        })
+        .Build();
+    var service = new EmailService(mockLogger.Object, configuration);
+
+    await service.SendInviteEmailAsync("user@example.com", "test-token");
+
+    mockLogger.Verify(
+        l => l.Log(
+            LogLevel.Information,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("dev stub")),
+            null,
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+        Times.Once);
+  }
+
+  [Fact]
+  public async Task SendInviteEmailAsync_WhenSmtpHostIsNull_LogsDevStubAndReturns()
+  {
+    var mockLogger = new Mock<ILogger<EmailService>>();
+    var configuration = new ConfigurationBuilder()
+        .AddInMemoryCollection(new Dictionary<string, string?>
+        {
+          ["InviteSettings:FrontendUrl"] = "http://localhost:3000"
+        })
+        .Build();
+    var service = new EmailService(mockLogger.Object, configuration);
+
+    await service.SendInviteEmailAsync("user@example.com", "test-token");
+
+    mockLogger.Verify(
+        l => l.Log(
+            LogLevel.Information,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("dev stub")),
+            null,
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+        Times.Once);
+  }
+}

--- a/AuthService/src/AuthService/AuthService.csproj
+++ b/AuthService/src/AuthService/AuthService.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MailKit" Version="4.10.0" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.3.6" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.0" />

--- a/AuthService/src/AuthService/Services/EmailService.cs
+++ b/AuthService/src/AuthService/Services/EmailService.cs
@@ -1,9 +1,9 @@
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using MimeKit;
+
 namespace AuthService.Services;
 
-/// <summary>
-/// Development stub: logs the invite link rather than sending a real email.
-/// Replace with an SMTP or third-party email provider implementation for production.
-/// </summary>
 public class EmailService : IEmailService
 {
   private readonly ILogger<EmailService> _logger;
@@ -15,16 +15,54 @@ public class EmailService : IEmailService
     _configuration = configuration;
   }
 
-  public Task SendInviteEmailAsync(string toEmail, string inviteToken)
+  public async Task SendInviteEmailAsync(string toEmail, string inviteToken)
   {
     var frontendUrl = _configuration["InviteSettings:FrontendUrl"] ?? "http://localhost:3000";
     var acceptUrl = $"{frontendUrl}/accept-invite?token={inviteToken}";
 
-    _logger.LogInformation(
-        "INVITE EMAIL (dev stub) — To: {Email} | Accept URL: {AcceptUrl}",
-        toEmail,
-        acceptUrl);
+    var smtpHost = _configuration["Smtp:Host"];
+    if (string.IsNullOrWhiteSpace(smtpHost))
+    {
+      _logger.LogInformation(
+          "INVITE EMAIL (dev stub — no SMTP configured) — To: {Email} | Accept URL: {AcceptUrl}",
+          toEmail,
+          acceptUrl);
+      return;
+    }
 
-    return Task.CompletedTask;
+    var smtpPort = int.TryParse(_configuration["Smtp:Port"], out var port) ? port : 587;
+    var smtpUser = _configuration["Smtp:Username"] ?? string.Empty;
+    var smtpPass = _configuration["Smtp:Password"] ?? string.Empty;
+    var fromAddress = _configuration["Smtp:FromAddress"] ?? smtpUser;
+    var fromName = _configuration["Smtp:FromName"] ?? "CRM System";
+    var useSsl = string.Equals(_configuration["Smtp:SecureSocketOptions"], "SslOnConnect",
+        StringComparison.OrdinalIgnoreCase);
+
+    var message = new MimeMessage();
+    message.From.Add(new MailboxAddress(fromName, fromAddress));
+    message.To.Add(new MailboxAddress(string.Empty, toEmail));
+    message.Subject = "You have been invited";
+
+    message.Body = new BodyBuilder
+    {
+      HtmlBody = $"""
+        <p>You have been invited to join. Click the link below to accept:</p>
+        <p><a href="{acceptUrl}">{acceptUrl}</a></p>
+        <p>This link expires in {_configuration["InviteSettings:TokenExpiryHours"] ?? "48"} hours.</p>
+        """,
+      TextBody = $"You have been invited. Accept at: {acceptUrl}"
+    }.ToMessageBody();
+
+    using var client = new SmtpClient();
+    var socketOptions = useSsl ? SecureSocketOptions.SslOnConnect : SecureSocketOptions.StartTlsWhenAvailable;
+    await client.ConnectAsync(smtpHost, smtpPort, socketOptions);
+
+    if (!string.IsNullOrEmpty(smtpUser))
+      await client.AuthenticateAsync(smtpUser, smtpPass);
+
+    await client.SendAsync(message);
+    await client.DisconnectAsync(true);
+
+    _logger.LogInformation("Invite email sent to {Email}", toEmail);
   }
 }

--- a/AuthService/src/AuthService/appsettings.json
+++ b/AuthService/src/AuthService/appsettings.json
@@ -24,5 +24,14 @@
   "InviteSettings": {
     "TokenExpiryHours": 48,
     "FrontendUrl": "http://localhost:3000"
+  },
+  "Smtp": {
+    "Host": "",
+    "Port": 587,
+    "Username": "",
+    "Password": "",
+    "FromAddress": "",
+    "FromName": "CRM System",
+    "SecureSocketOptions": "StartTlsWhenAvailable"
   }
 }


### PR DESCRIPTION
Adds MailKit 4.10.0 to AuthService and replaces the dev stub EmailService with a real SMTP implementation. Falls back to logging when no SMTP host is configured.

Closes #88

Generated with [Claude Code](https://claude.ai/code)