### PR TITLE
feat: Force password change on first login (issue #37)

### DIFF
--- a/AuthService/src/AuthService.Tests/Controllers/ChangePasswordControllerTests.cs
+++ b/AuthService/src/AuthService.Tests/Controllers/ChangePasswordControllerTests.cs
@@ -1,0 +1,144 @@
+using System.Reflection;
+using Moq;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System.Security.Claims;
+using AuthService.Controllers;
+using AuthService.Models.DTOs;
+using AuthService.Services;
+
+public class ChangePasswordControllerTests
+{
+  private readonly Mock<IChangePasswordService> _mockChangePasswordService;
+  private readonly Mock<ILogger<ChangePasswordController>> _mockLogger;
+  private readonly ChangePasswordController _controller;
+  private readonly Guid _userId = Guid.NewGuid();
+
+  public ChangePasswordControllerTests()
+  {
+    _mockChangePasswordService = new Mock<IChangePasswordService>();
+    _mockLogger = new Mock<ILogger<ChangePasswordController>>();
+    _controller = new ChangePasswordController(_mockChangePasswordService.Object, _mockLogger.Object);
+
+    var claims = new List<Claim> { new Claim("UserId", _userId.ToString()) };
+    _controller.ControllerContext = new ControllerContext
+    {
+      HttpContext = new DefaultHttpContext
+      {
+        User = new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"))
+      }
+    };
+  }
+
+  [Fact]
+  public async Task ChangePassword_ShouldReturnOk_WithNewToken_WhenSuccessful()
+  {
+    // Arrange
+    var request = new ChangePasswordRequest { NewPassword = "NewSecurePass123!" };
+    var loginResponse = new LoginResponse { Token = "new-jwt-token" };
+    _mockChangePasswordService
+        .Setup(s => s.ChangePasswordAsync(_userId, request.NewPassword))
+        .ReturnsAsync(ServiceResult.Success(loginResponse, "Password changed successfully."));
+
+    // Act
+    var result = await _controller.ChangePassword(request);
+
+    // Assert
+    var ok = Assert.IsType<OkObjectResult>(result);
+    var response = Assert.IsType<LoginResponse>(ok.Value);
+    Assert.Equal("new-jwt-token", response.Token);
+  }
+
+  [Fact]
+  public async Task ChangePassword_ShouldReturnBadRequest_WhenNewPasswordIsEmpty()
+  {
+    // Arrange
+    var request = new ChangePasswordRequest { NewPassword = "" };
+
+    // Act
+    var result = await _controller.ChangePassword(request);
+
+    // Assert
+    var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+    Assert.Contains("New password is required.", badRequest.Value!.ToString());
+    _mockChangePasswordService.Verify(s => s.ChangePasswordAsync(It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task ChangePassword_ShouldReturnBadRequest_WhenRequestIsNull()
+  {
+    // Act
+    var result = await _controller.ChangePassword(null!);
+
+    // Assert
+    var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+    Assert.Contains("New password is required.", badRequest.Value!.ToString());
+  }
+
+  [Fact]
+  public async Task ChangePassword_ShouldReturnUnauthorized_WhenUserIdClaimIsMissing()
+  {
+    // Arrange
+    var controller = new ChangePasswordController(_mockChangePasswordService.Object, _mockLogger.Object);
+    controller.ControllerContext = new ControllerContext
+    {
+      HttpContext = new DefaultHttpContext
+      {
+        User = new ClaimsPrincipal(new ClaimsIdentity(new List<Claim>(), "Test"))
+      }
+    };
+    var request = new ChangePasswordRequest { NewPassword = "NewPass123!" };
+
+    // Act
+    var result = await controller.ChangePassword(request);
+
+    // Assert
+    var unauthorized = Assert.IsType<UnauthorizedObjectResult>(result);
+    Assert.Contains("Invalid token.", unauthorized.Value!.ToString());
+  }
+
+  [Fact]
+  public async Task ChangePassword_ShouldReturn404_WhenUserNotFound()
+  {
+    // Arrange
+    var request = new ChangePasswordRequest { NewPassword = "NewPass123!" };
+    _mockChangePasswordService
+        .Setup(s => s.ChangePasswordAsync(_userId, request.NewPassword))
+        .ReturnsAsync(ServiceResult.Failure("User not found.", 404));
+
+    // Act
+    var result = await _controller.ChangePassword(request);
+
+    // Assert
+    var statusResult = Assert.IsType<ObjectResult>(result);
+    Assert.Equal(404, statusResult.StatusCode);
+  }
+
+  [Fact]
+  public async Task ChangePassword_ShouldReturn500_WhenExceptionIsThrown()
+  {
+    // Arrange
+    var request = new ChangePasswordRequest { NewPassword = "NewPass123!" };
+    _mockChangePasswordService
+        .Setup(s => s.ChangePasswordAsync(_userId, request.NewPassword))
+        .ThrowsAsync(new Exception("DB error"));
+
+    // Act
+    var result = await _controller.ChangePassword(request);
+
+    // Assert
+    var statusResult = Assert.IsType<ObjectResult>(result);
+    Assert.Equal(500, statusResult.StatusCode);
+  }
+
+  [Fact]
+  public void ChangePassword_ShouldRequireAuthorization()
+  {
+    var method = typeof(ChangePasswordController).GetMethod(nameof(ChangePasswordController.ChangePassword));
+    var authorizeAttr = method!.GetCustomAttribute<AuthorizeAttribute>();
+
+    Assert.NotNull(authorizeAttr);
+  }
+}

--- a/AuthService/src/AuthService.Tests/Services/ChangePasswordServiceTests.cs
+++ b/AuthService/src/AuthService.Tests/Services/ChangePasswordServiceTests.cs
@@ -1,0 +1,115 @@
+using Moq;
+using Microsoft.Extensions.Logging;
+using AuthService.Models;
+using AuthService.Models.DTOs;
+using AuthService.Repository;
+using AuthService.Services;
+using SharedLibrary.Enums;
+
+public class ChangePasswordServiceTests
+{
+  private readonly Mock<IUserRepository> _mockUserRepository;
+  private readonly Mock<IPasswordService> _mockPasswordService;
+  private readonly Mock<IJwtTokenService> _mockJwtTokenService;
+  private readonly Mock<IUserRoleClient> _mockUserRoleClient;
+  private readonly Mock<ILogger<ChangePasswordService>> _mockLogger;
+  private readonly ChangePasswordService _service;
+
+  public ChangePasswordServiceTests()
+  {
+    _mockUserRepository = new Mock<IUserRepository>();
+    _mockPasswordService = new Mock<IPasswordService>();
+    _mockJwtTokenService = new Mock<IJwtTokenService>();
+    _mockUserRoleClient = new Mock<IUserRoleClient>();
+    _mockLogger = new Mock<ILogger<ChangePasswordService>>();
+
+    _service = new ChangePasswordService(
+        _mockUserRepository.Object,
+        _mockPasswordService.Object,
+        _mockJwtTokenService.Object,
+        _mockUserRoleClient.Object,
+        _mockLogger.Object);
+  }
+
+  [Fact]
+  public async Task ChangePasswordAsync_ShouldUpdatePasswordAndClearFlag_WhenUserExists()
+  {
+    // Arrange
+    var userId = Guid.NewGuid();
+    var newPassword = "NewSecurePass123!";
+    var user = new User
+    {
+      UserId = userId,
+      Email = "user@example.com",
+      PasswordHash = "old-hash",
+      MustChangePassword = true
+    };
+
+    _mockUserRepository.Setup(r => r.GetUserByIdAsync(userId)).ReturnsAsync(user);
+    _mockPasswordService.Setup(p => p.HashPassword(newPassword)).Returns("new-hash");
+    _mockUserRepository.Setup(r => r.UpdateUserAsync(It.IsAny<User>())).Returns(Task.CompletedTask);
+    _mockUserRoleClient.Setup(c => c.GetRoleAsync(userId))
+        .ReturnsAsync(new UserRoleResponse { Role = UserRole.Member, IsActive = true });
+    _mockJwtTokenService.Setup(j => j.GenerateJwtToken(It.IsAny<User>(), UserRole.Member))
+        .Returns("new-jwt-token");
+
+    // Act
+    var result = await _service.ChangePasswordAsync(userId, newPassword);
+
+    // Assert
+    Assert.True(result.IsSuccess);
+    Assert.Equal(200, result.StatusCode);
+    _mockUserRepository.Verify(
+        r => r.UpdateUserAsync(It.Is<User>(u => u.PasswordHash == "new-hash" && !u.MustChangePassword)),
+        Times.Once);
+    var response = result.Data as LoginResponse;
+    Assert.NotNull(response);
+    Assert.Equal("new-jwt-token", response.Token);
+  }
+
+  [Fact]
+  public async Task ChangePasswordAsync_ShouldReturnFailure_WhenUserNotFound()
+  {
+    // Arrange
+    var userId = Guid.NewGuid();
+    _mockUserRepository.Setup(r => r.GetUserByIdAsync(userId)).ReturnsAsync((User?)null);
+
+    // Act
+    var result = await _service.ChangePasswordAsync(userId, "NewPass123!");
+
+    // Assert
+    Assert.False(result.IsSuccess);
+    Assert.Equal(404, result.StatusCode);
+    _mockUserRepository.Verify(r => r.UpdateUserAsync(It.IsAny<User>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task ChangePasswordAsync_ShouldReturnFailure_WhenNewPasswordIsEmpty()
+  {
+    // Arrange
+    var userId = Guid.NewGuid();
+
+    // Act
+    var result = await _service.ChangePasswordAsync(userId, "");
+
+    // Assert
+    Assert.False(result.IsSuccess);
+    Assert.Equal(400, result.StatusCode);
+    _mockUserRepository.Verify(r => r.GetUserByIdAsync(It.IsAny<Guid>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task ChangePasswordAsync_ShouldReturnFailure_WhenNewPasswordIsWhitespace()
+  {
+    // Arrange
+    var userId = Guid.NewGuid();
+
+    // Act
+    var result = await _service.ChangePasswordAsync(userId, "   ");
+
+    // Assert
+    Assert.False(result.IsSuccess);
+    Assert.Equal(400, result.StatusCode);
+    _mockUserRepository.Verify(r => r.GetUserByIdAsync(It.IsAny<Guid>()), Times.Never);
+  }
+}

--- a/AuthService/src/AuthService.Tests/Services/InviteServiceTests.cs
+++ b/AuthService/src/AuthService.Tests/Services/InviteServiceTests.cs
@@ -114,7 +114,7 @@ public class InviteServiceTests
     Assert.True(result.IsSuccess);
     Assert.Equal(200, result.StatusCode);
     _mockUserRepository.Verify(
-        r => r.AddUserAsync(It.Is<User>(u => u.Email == inviteToken.Email)),
+        r => r.AddUserAsync(It.Is<User>(u => u.Email == inviteToken.Email && u.MustChangePassword)),
         Times.Once);
     _mockInviteTokenRepository.Verify(
         r => r.UpdateAsync(It.Is<InviteToken>(t => t.IsUsed)),

--- a/AuthService/src/AuthService.Tests/Services/JwtTokenServiceTests.cs
+++ b/AuthService/src/AuthService.Tests/Services/JwtTokenServiceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IdentityModel.Tokens.Jwt;
 using AuthService.Models;
 using AuthService.Services;
 using Microsoft.Extensions.Configuration;
@@ -50,5 +51,39 @@ public class JwtTokenServiceTests
 
     Assert.NotNull(token);
     Assert.NotEmpty(token);
+  }
+
+  [Fact]
+  public void GenerateJwtToken_ShouldIncludeMustChangePasswordClaim_WhenTrue()
+  {
+    // Arrange
+    var user = new User { UserId = Guid.NewGuid(), Email = "invited@example.com", MustChangePassword = true };
+
+    // Act
+    var token = _jwtTokenService.GenerateJwtToken(user, UserRole.Member);
+
+    // Assert
+    var handler = new JwtSecurityTokenHandler();
+    var parsed = handler.ReadJwtToken(token);
+    var claim = parsed.Claims.FirstOrDefault(c => c.Type == "MustChangePassword");
+    Assert.NotNull(claim);
+    Assert.Equal("true", claim.Value);
+  }
+
+  [Fact]
+  public void GenerateJwtToken_ShouldIncludeMustChangePasswordClaim_WhenFalse()
+  {
+    // Arrange
+    var user = new User { UserId = Guid.NewGuid(), Email = "user@example.com", MustChangePassword = false };
+
+    // Act
+    var token = _jwtTokenService.GenerateJwtToken(user, UserRole.Member);
+
+    // Assert
+    var handler = new JwtSecurityTokenHandler();
+    var parsed = handler.ReadJwtToken(token);
+    var claim = parsed.Claims.FirstOrDefault(c => c.Type == "MustChangePassword");
+    Assert.NotNull(claim);
+    Assert.Equal("false", claim.Value);
   }
 }

--- a/AuthService/src/AuthService/Controllers/ChangePasswordController.cs
+++ b/AuthService/src/AuthService/Controllers/ChangePasswordController.cs
@@ -1,0 +1,61 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using AuthService.Models.DTOs;
+using AuthService.Services;
+
+namespace AuthService.Controllers;
+
+[ApiController]
+public class ChangePasswordController : ControllerBase
+{
+  private readonly IChangePasswordService _changePasswordService;
+  private readonly ILogger<ChangePasswordController> _logger;
+
+  public ChangePasswordController(IChangePasswordService changePasswordService, ILogger<ChangePasswordController> logger)
+  {
+    _changePasswordService = changePasswordService;
+    _logger = logger;
+  }
+
+  // <summary>
+  // Change password for the authenticated user and clear the MustChangePassword flag.
+  // Returns a new JWT token with MustChangePassword set to false.
+  // </summary>
+  // <response code="200">Password changed, new token returned</response>
+  // <response code="400">New password is required</response>
+  // <response code="401">Not authenticated</response>
+  // <response code="500">Internal server error</response>
+  [Authorize]
+  [HttpPost("api/auth/change-password")]
+  public async Task<IActionResult> ChangePassword([FromBody] ChangePasswordRequest request)
+  {
+    if (request == null || string.IsNullOrWhiteSpace(request.NewPassword))
+    {
+      return BadRequest(new { message = "New password is required." });
+    }
+
+    var userIdStr = User.FindFirstValue("UserId");
+    if (!Guid.TryParse(userIdStr, out var userId))
+    {
+      return Unauthorized(new { message = "Invalid token." });
+    }
+
+    try
+    {
+      var result = await _changePasswordService.ChangePasswordAsync(userId, request.NewPassword);
+
+      if (!result.IsSuccess)
+      {
+        return StatusCode(result.StatusCode, new { message = result.Message });
+      }
+
+      return Ok(result.Data);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "An error occurred while changing the password.");
+      return StatusCode(500, new { message = "An internal server error occurred." });
+    }
+  }
+}

--- a/AuthService/src/AuthService/Models/DTOs/ChangePasswordRequest.cs
+++ b/AuthService/src/AuthService/Models/DTOs/ChangePasswordRequest.cs
@@ -1,0 +1,6 @@
+namespace AuthService.Models.DTOs;
+
+public class ChangePasswordRequest
+{
+  public string NewPassword { get; set; } = string.Empty;
+}

--- a/AuthService/src/AuthService/Models/User.cs
+++ b/AuthService/src/AuthService/Models/User.cs
@@ -13,4 +13,6 @@ public class User
 
   [Required]
   public string PasswordHash { get; set; } = string.Empty;
+
+  public bool MustChangePassword { get; set; } = false;
 }

--- a/AuthService/src/AuthService/Program.cs
+++ b/AuthService/src/AuthService/Program.cs
@@ -53,6 +53,7 @@ builder.Services.AddScoped<ILoginService, LoginService>();
 builder.Services.AddScoped<IEmailService, EmailService>();
 builder.Services.AddScoped<IInviteService, InviteService>();
 builder.Services.AddScoped<IForgotPasswordService, ForgotPasswordService>();
+builder.Services.AddScoped<IChangePasswordService, ChangePasswordService>();
 
 // Typed HttpClient for role fetch (sync call on login)
 builder.Services.AddHttpClient<IUserRoleClient, UserRoleClient>(client =>

--- a/AuthService/src/AuthService/Services/ChangePasswordService.cs
+++ b/AuthService/src/AuthService/Services/ChangePasswordService.cs
@@ -1,0 +1,52 @@
+using AuthService.Models.DTOs;
+using AuthService.Repository;
+
+namespace AuthService.Services;
+
+public class ChangePasswordService : IChangePasswordService
+{
+  private readonly IUserRepository _userRepository;
+  private readonly IPasswordService _passwordService;
+  private readonly IJwtTokenService _jwtTokenService;
+  private readonly IUserRoleClient _userRoleClient;
+  private readonly ILogger<ChangePasswordService> _logger;
+
+  public ChangePasswordService(
+      IUserRepository userRepository,
+      IPasswordService passwordService,
+      IJwtTokenService jwtTokenService,
+      IUserRoleClient userRoleClient,
+      ILogger<ChangePasswordService> logger)
+  {
+    _userRepository = userRepository;
+    _passwordService = passwordService;
+    _jwtTokenService = jwtTokenService;
+    _userRoleClient = userRoleClient;
+    _logger = logger;
+  }
+
+  public async Task<ServiceResult> ChangePasswordAsync(Guid userId, string newPassword)
+  {
+    if (string.IsNullOrWhiteSpace(newPassword))
+    {
+      return ServiceResult.Failure("New password is required.", 400);
+    }
+
+    var user = await _userRepository.GetUserByIdAsync(userId);
+    if (user == null)
+    {
+      _logger.LogWarning("ChangePassword failed: User {UserId} not found.", userId);
+      return ServiceResult.Failure("User not found.", 404);
+    }
+
+    user.PasswordHash = _passwordService.HashPassword(newPassword);
+    user.MustChangePassword = false;
+    await _userRepository.UpdateUserAsync(user);
+
+    var userStatus = await _userRoleClient.GetRoleAsync(userId);
+    var newToken = _jwtTokenService.GenerateJwtToken(user, userStatus.Role);
+
+    _logger.LogInformation("User {UserId} changed password successfully.", userId);
+    return ServiceResult.Success(new LoginResponse { Token = newToken }, "Password changed successfully.");
+  }
+}

--- a/AuthService/src/AuthService/Services/IChangePasswordService.cs
+++ b/AuthService/src/AuthService/Services/IChangePasswordService.cs
@@ -1,0 +1,6 @@
+namespace AuthService.Services;
+
+public interface IChangePasswordService
+{
+  Task<ServiceResult> ChangePasswordAsync(Guid userId, string newPassword);
+}

--- a/AuthService/src/AuthService/Services/InviteService.cs
+++ b/AuthService/src/AuthService/Services/InviteService.cs
@@ -91,7 +91,8 @@ public class InviteService : IInviteService
     {
       UserId = Guid.NewGuid(),
       Email = inviteToken.Email,
-      PasswordHash = _passwordService.HashPassword(password)
+      PasswordHash = _passwordService.HashPassword(password),
+      MustChangePassword = true
     };
 
     await _userRepository.AddUserAsync(user);

--- a/AuthService/src/AuthService/Services/JwtTokenService.cs
+++ b/AuthService/src/AuthService/Services/JwtTokenService.cs
@@ -38,6 +38,7 @@ public class JwtTokenService : IJwtTokenService
       new Claim(JwtRegisteredClaimNames.Sub, user.Email),
       new Claim("UserId", user.UserId.ToString()),
       new Claim(ClaimTypes.Role, role.ToString()),
+      new Claim("MustChangePassword", user.MustChangePassword.ToString().ToLower()),
       new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
     };
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import AdminRoute from './components/AdminRoute.jsx'
 import Layout from './components/Layout.jsx'
 import Login from './pages/auth/Login.jsx'
 import Register from './pages/auth/Register.jsx'
+import ChangePassword from './pages/auth/ChangePassword.jsx'
 import Profile from './pages/profile/Profile.jsx'
 import ContactList from './pages/contacts/ContactList.jsx'
 import ContactDetail from './pages/contacts/ContactDetail.jsx'
@@ -26,6 +27,9 @@ export default function App() {
         <Routes>
           <Route path="/login" element={<Login />} />
           <Route path="/register" element={<Register />} />
+          <Route element={<ProtectedRoute />}>
+            <Route path="/change-password" element={<ChangePassword />} />
+          </Route>
           <Route element={<ProtectedRoute />}>
             <Route element={<Layout />}>
               <Route index element={<Navigate to="/contacts" replace />} />

--- a/frontend/src/api/auth.api.js
+++ b/frontend/src/api/auth.api.js
@@ -14,4 +14,9 @@ export const authApi = {
       body: JSON.stringify({ email, password }),
     }),
   me: () => apiFetch(`${BASE}/login/me`),
+  changePassword: (newPassword) =>
+    apiFetch(`${BASE}/auth/change-password`, {
+      method: 'POST',
+      body: JSON.stringify({ newPassword }),
+    }),
 }

--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -1,7 +1,15 @@
-import { Navigate, Outlet } from 'react-router-dom'
+import { Navigate, Outlet, useLocation } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext.jsx'
 
 export default function ProtectedRoute() {
-  const { token } = useAuth()
-  return token ? <Outlet /> : <Navigate to="/login" replace />
+  const { token, user } = useAuth()
+  const location = useLocation()
+
+  if (!token) return <Navigate to="/login" replace />
+
+  if (user?.mustChangePassword && location.pathname !== '/change-password') {
+    return <Navigate to="/change-password" replace />
+  }
+
+  return <Outlet />
 }

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -10,6 +10,7 @@ function parseToken(token) {
       userId: payload['UserId'],
       email: payload['sub'],
       role: payload['http://schemas.microsoft.com/ws/2008/06/identity/claims/role'],
+      mustChangePassword: payload['MustChangePassword'] === 'true',
     }
   } catch {
     return null

--- a/frontend/src/pages/auth/ChangePassword.jsx
+++ b/frontend/src/pages/auth/ChangePassword.jsx
@@ -1,0 +1,87 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { authApi } from '../../api/auth.api.js'
+import { useAuth } from '../../context/AuthContext.jsx'
+import { Button } from '../../components/ui/button.jsx'
+import { Input } from '../../components/ui/input.jsx'
+import { Label } from '../../components/ui/label.jsx'
+import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card.jsx'
+
+export default function ChangePassword() {
+  const { login } = useAuth()
+  const navigate = useNavigate()
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [error, setError] = useState(null)
+  const [loading, setLoading] = useState(false)
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    setError(null)
+
+    if (newPassword !== confirmPassword) {
+      setError('Passwords do not match.')
+      return
+    }
+
+    setLoading(true)
+    try {
+      const data = await authApi.changePassword(newPassword)
+      login(data.token)
+      navigate('/contacts', { replace: true })
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <Card className="w-full max-w-sm shadow-md">
+        <CardHeader>
+          <CardTitle className="text-xl">Set your password</CardTitle>
+          <p className="text-sm text-gray-500 mt-1">
+            You must set a new password before continuing.
+          </p>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+            {error && (
+              <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-md border border-red-200">
+                {error}
+              </p>
+            )}
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="newPassword">New password</Label>
+              <Input
+                id="newPassword"
+                type="password"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                required
+                minLength={6}
+                autoComplete="new-password"
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="confirmPassword">Confirm password</Label>
+              <Input
+                id="confirmPassword"
+                type="password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                required
+                minLength={6}
+                autoComplete="new-password"
+              />
+            </div>
+            <Button type="submit" disabled={loading} className="w-full">
+              {loading ? 'Saving…' : 'Set password'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
Implements force-password-change for invite-accepted users as described in issue #37.

## Changes

**Backend:**
- `User.MustChangePassword` flag (defaults false)
- JWT now includes `MustChangePassword` claim
- `InviteService` sets flag = true on invite accept
- `POST /api/auth/change-password` (Authorize) - clears flag, returns new JWT

**Frontend:**
- `AuthContext` parses `mustChangePassword` from token
- `ProtectedRoute` redirects to `/change-password` when flag is set
- New `ChangePassword` page and route

Closes #37

Generated with [Claude Code](https://claude.ai/code)