### PR TITLE
feat: [Option A] Password policy enforcement

### DIFF
--- a/AuthService/src/AuthService.Tests/Services/ChangePasswordServiceTests.cs
+++ b/AuthService/src/AuthService.Tests/Services/ChangePasswordServiceTests.cs
@@ -13,6 +13,7 @@ public class ChangePasswordServiceTests
   private readonly Mock<IJwtTokenService> _mockJwtTokenService;
   private readonly Mock<IUserRoleClient> _mockUserRoleClient;
   private readonly Mock<ILogger<ChangePasswordService>> _mockLogger;
+  private readonly Mock<IPasswordPolicyService> _mockPasswordPolicyService;
   private readonly ChangePasswordService _service;
 
   public ChangePasswordServiceTests()
@@ -22,13 +23,20 @@ public class ChangePasswordServiceTests
     _mockJwtTokenService = new Mock<IJwtTokenService>();
     _mockUserRoleClient = new Mock<IUserRoleClient>();
     _mockLogger = new Mock<ILogger<ChangePasswordService>>();
+    _mockPasswordPolicyService = new Mock<IPasswordPolicyService>();
+
+    // Default: policy passes
+    _mockPasswordPolicyService
+        .Setup(p => p.Validate(It.IsAny<string>()))
+        .Returns((true, (IReadOnlyList<string>)Array.Empty<string>()));
 
     _service = new ChangePasswordService(
         _mockUserRepository.Object,
         _mockPasswordService.Object,
         _mockJwtTokenService.Object,
         _mockUserRoleClient.Object,
-        _mockLogger.Object);
+        _mockLogger.Object,
+        _mockPasswordPolicyService.Object);
   }
 
   [Fact]
@@ -95,6 +103,24 @@ public class ChangePasswordServiceTests
     // Assert
     Assert.False(result.IsSuccess);
     Assert.Equal(400, result.StatusCode);
+    _mockUserRepository.Verify(r => r.GetUserByIdAsync(It.IsAny<Guid>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task ChangePasswordAsync_ShouldReturnFailure_WhenPasswordViolatesPolicy()
+  {
+    // Arrange
+    var userId = Guid.NewGuid();
+    var errors = (IReadOnlyList<string>)new[] { "Password must contain at least one uppercase letter." };
+    _mockPasswordPolicyService.Setup(p => p.Validate("alllower1!")).Returns((false, errors));
+
+    // Act
+    var result = await _service.ChangePasswordAsync(userId, "alllower1!");
+
+    // Assert
+    Assert.False(result.IsSuccess);
+    Assert.Equal(400, result.StatusCode);
+    Assert.Contains("uppercase", result.Message);
     _mockUserRepository.Verify(r => r.GetUserByIdAsync(It.IsAny<Guid>()), Times.Never);
   }
 

--- a/AuthService/src/AuthService.Tests/Services/ForgotPasswordServiceTests.cs
+++ b/AuthService/src/AuthService.Tests/Services/ForgotPasswordServiceTests.cs
@@ -10,6 +10,7 @@ public class ForgotPasswordServiceTests
   private readonly Mock<IPasswordResetTokenRepository> _mockResetTokenRepository;
   private readonly Mock<IPasswordService> _mockPasswordService;
   private readonly Mock<IEmailService> _mockEmailService;
+  private readonly Mock<IPasswordPolicyService> _mockPasswordPolicyService;
   private readonly ForgotPasswordService _service;
 
   public ForgotPasswordServiceTests()
@@ -18,12 +19,19 @@ public class ForgotPasswordServiceTests
     _mockResetTokenRepository = new Mock<IPasswordResetTokenRepository>();
     _mockPasswordService = new Mock<IPasswordService>();
     _mockEmailService = new Mock<IEmailService>();
+    _mockPasswordPolicyService = new Mock<IPasswordPolicyService>();
+
+    // Default: policy passes
+    _mockPasswordPolicyService
+        .Setup(p => p.Validate(It.IsAny<string>()))
+        .Returns((true, (IReadOnlyList<string>)Array.Empty<string>()));
 
     _service = new ForgotPasswordService(
         _mockUserRepository.Object,
         _mockResetTokenRepository.Object,
         _mockPasswordService.Object,
-        _mockEmailService.Object);
+        _mockEmailService.Object,
+        _mockPasswordPolicyService.Object);
   }
 
   // ── ForgotPasswordAsync ──────────────────────────────────────────────────────
@@ -100,6 +108,20 @@ public class ForgotPasswordServiceTests
     Assert.True(result.IsSuccess);
     _mockUserRepository.Verify(r => r.UpdateUserAsync(It.Is<User>(u => u.PasswordHash == "new-hash")), Times.Once);
     _mockResetTokenRepository.Verify(r => r.UpdateAsync(It.Is<PasswordResetToken>(t => t.IsUsed)), Times.Once);
+  }
+
+  [Fact]
+  public async Task ResetPasswordAsync_ShouldReturnFailure_WhenPasswordViolatesPolicy()
+  {
+    var errors = (IReadOnlyList<string>)new[] { "Password must be at least 8 characters long." };
+    _mockPasswordPolicyService.Setup(p => p.Validate("weak")).Returns((false, errors));
+
+    var result = await _service.ResetPasswordAsync("any-token", "weak");
+
+    Assert.False(result.IsSuccess);
+    Assert.Equal(400, result.StatusCode);
+    Assert.Contains("8 characters", result.Message);
+    _mockResetTokenRepository.Verify(r => r.GetByTokenAsync(It.IsAny<string>()), Times.Never);
   }
 
   [Fact]

--- a/AuthService/src/AuthService.Tests/Services/InviteServiceTests.cs
+++ b/AuthService/src/AuthService.Tests/Services/InviteServiceTests.cs
@@ -13,6 +13,7 @@ public class InviteServiceTests
   private readonly Mock<IPasswordService> _mockPasswordService;
   private readonly Mock<IEmailService> _mockEmailService;
   private readonly Mock<IPublishEndpoint> _mockPublishEndpoint;
+  private readonly Mock<IPasswordPolicyService> _mockPasswordPolicyService;
   private readonly IConfiguration _configuration;
   private readonly InviteService _service;
 
@@ -23,6 +24,12 @@ public class InviteServiceTests
     _mockPasswordService = new Mock<IPasswordService>();
     _mockEmailService = new Mock<IEmailService>();
     _mockPublishEndpoint = new Mock<IPublishEndpoint>();
+    _mockPasswordPolicyService = new Mock<IPasswordPolicyService>();
+
+    // Default: policy passes
+    _mockPasswordPolicyService
+        .Setup(p => p.Validate(It.IsAny<string>()))
+        .Returns((true, (IReadOnlyList<string>)Array.Empty<string>()));
 
     _configuration = new ConfigurationBuilder()
         .AddInMemoryCollection(new Dictionary<string, string?>
@@ -38,7 +45,8 @@ public class InviteServiceTests
         _mockPasswordService.Object,
         _mockEmailService.Object,
         _mockPublishEndpoint.Object,
-        _configuration);
+        _configuration,
+        _mockPasswordPolicyService.Object);
   }
 
   [Fact]
@@ -122,6 +130,20 @@ public class InviteServiceTests
     _mockPublishEndpoint.Verify(
         p => p.Publish(It.Is<UserRegistered>(e => e.Email == inviteToken.Email), It.IsAny<CancellationToken>()),
         Times.Once);
+  }
+
+  [Fact]
+  public async Task AcceptInviteAsync_ShouldReturnFailure_WhenPasswordViolatesPolicy()
+  {
+    var errors = (IReadOnlyList<string>)new[] { "Password must be at least 8 characters long." };
+    _mockPasswordPolicyService.Setup(p => p.Validate("weak")).Returns((false, errors));
+
+    var result = await _service.AcceptInviteAsync("any-token", "weak");
+
+    Assert.False(result.IsSuccess);
+    Assert.Equal(400, result.StatusCode);
+    Assert.Contains("8 characters", result.Message);
+    _mockInviteTokenRepository.Verify(r => r.GetByTokenAsync(It.IsAny<string>()), Times.Never);
   }
 
   [Fact]

--- a/AuthService/src/AuthService.Tests/Services/PasswordPolicyServiceTests.cs
+++ b/AuthService/src/AuthService.Tests/Services/PasswordPolicyServiceTests.cs
@@ -1,0 +1,120 @@
+using AuthService.Configuration;
+using AuthService.Services;
+using Microsoft.Extensions.Options;
+
+public class PasswordPolicyServiceTests
+{
+  private static PasswordPolicyService CreateService(PasswordPolicy? policy = null)
+  {
+    policy ??= new PasswordPolicy
+    {
+      MinimumLength = 8,
+      RequireUppercase = true,
+      RequireLowercase = true,
+      RequireDigit = true,
+      RequireSpecialCharacter = true,
+      SpecialCharacters = "!@#$%^&*()_+-=[]{}|;':\",./<>?"
+    };
+    return new PasswordPolicyService(Options.Create(policy));
+  }
+
+  [Fact]
+  public void Validate_ValidPassword_ReturnsSuccess()
+  {
+    var service = CreateService();
+    var (isValid, errors) = service.Validate("Secure1!");
+    Assert.True(isValid);
+    Assert.Empty(errors);
+  }
+
+  [Fact]
+  public void Validate_TooShort_ReturnsError()
+  {
+    var service = CreateService();
+    var (isValid, errors) = service.Validate("Ab1!");
+    Assert.False(isValid);
+    Assert.Contains(errors, e => e.Contains("8 characters"));
+  }
+
+  [Fact]
+  public void Validate_MissingUppercase_ReturnsError()
+  {
+    var service = CreateService();
+    var (isValid, errors) = service.Validate("secure1!");
+    Assert.False(isValid);
+    Assert.Contains(errors, e => e.Contains("uppercase"));
+  }
+
+  [Fact]
+  public void Validate_MissingLowercase_ReturnsError()
+  {
+    var service = CreateService();
+    var (isValid, errors) = service.Validate("SECURE1!");
+    Assert.False(isValid);
+    Assert.Contains(errors, e => e.Contains("lowercase"));
+  }
+
+  [Fact]
+  public void Validate_MissingDigit_ReturnsError()
+  {
+    var service = CreateService();
+    var (isValid, errors) = service.Validate("Securely!");
+    Assert.False(isValid);
+    Assert.Contains(errors, e => e.Contains("digit"));
+  }
+
+  [Fact]
+  public void Validate_MissingSpecialCharacter_ReturnsError()
+  {
+    var service = CreateService();
+    var (isValid, errors) = service.Validate("Secure123");
+    Assert.False(isValid);
+    Assert.Contains(errors, e => e.Contains("special character"));
+  }
+
+  [Fact]
+  public void Validate_MultipleViolations_ReturnsAllErrors()
+  {
+    var service = CreateService();
+    var (isValid, errors) = service.Validate("short");
+    Assert.False(isValid);
+    Assert.True(errors.Count > 1);
+  }
+
+  [Fact]
+  public void Validate_WhenComplexityRulesDisabled_AcceptsSimplePassword()
+  {
+    var policy = new PasswordPolicy
+    {
+      MinimumLength = 4,
+      RequireUppercase = false,
+      RequireLowercase = false,
+      RequireDigit = false,
+      RequireSpecialCharacter = false
+    };
+    var service = CreateService(policy);
+    var (isValid, errors) = service.Validate("abcd");
+    Assert.True(isValid);
+    Assert.Empty(errors);
+  }
+
+  [Fact]
+  public void Validate_CustomMinimumLength_EnforcesCorrectLength()
+  {
+    var policy = new PasswordPolicy
+    {
+      MinimumLength = 12,
+      RequireUppercase = false,
+      RequireLowercase = false,
+      RequireDigit = false,
+      RequireSpecialCharacter = false
+    };
+    var service = CreateService(policy);
+
+    var (shortValid, _) = service.Validate("ShortPass1!");
+    var (longValid, _) = service.Validate("LongEnoughPass1!");
+
+    Assert.False(shortValid);
+    Assert.True(longValid);
+  }
+}

--- a/AuthService/src/AuthService.Tests/Services/RegistrationServiceTests.cs
+++ b/AuthService/src/AuthService.Tests/Services/RegistrationServiceTests.cs
@@ -10,6 +10,7 @@ public class RegistrationServiceTests
   private readonly Mock<IUserRepository> _mockUserRepository;
   private readonly Mock<IPasswordService> _mockPasswordService;
   private readonly Mock<IPublishEndpoint> _mockPublishEndpoint;
+  private readonly Mock<IPasswordPolicyService> _mockPasswordPolicyService;
   private readonly RegistationService _service;
 
   public RegistrationServiceTests()
@@ -17,11 +18,18 @@ public class RegistrationServiceTests
     _mockUserRepository = new Mock<IUserRepository>();
     _mockPasswordService = new Mock<IPasswordService>();
     _mockPublishEndpoint = new Mock<IPublishEndpoint>();
+    _mockPasswordPolicyService = new Mock<IPasswordPolicyService>();
+
+    // Default: policy passes
+    _mockPasswordPolicyService
+        .Setup(p => p.Validate(It.IsAny<string>()))
+        .Returns((true, (IReadOnlyList<string>)Array.Empty<string>()));
 
     _service = new RegistationService(
         _mockUserRepository.Object,
         _mockPasswordService.Object,
-        _mockPublishEndpoint.Object);
+        _mockPublishEndpoint.Object,
+        _mockPasswordPolicyService.Object);
   }
 
   [Fact]
@@ -68,6 +76,25 @@ public class RegistrationServiceTests
     _mockPublishEndpoint.Verify(
         p => p.Publish(It.IsAny<UserRegistered>(), It.IsAny<CancellationToken>()),
         Times.Never);
+  }
+
+  [Fact]
+  public async Task RegisterUserAsync_ShouldReturnFailure_WhenPasswordViolatesPolicy()
+  {
+    // Arrange
+    var errors = (IReadOnlyList<string>)new[] { "Password must be at least 8 characters long." };
+    _mockPasswordPolicyService
+        .Setup(p => p.Validate("weak"))
+        .Returns((false, errors));
+
+    // Act
+    var result = await _service.RegisterUserAsync("user@example.com", "weak");
+
+    // Assert
+    Assert.False(result.IsSuccess);
+    Assert.Equal(400, result.StatusCode);
+    Assert.Contains("8 characters", result.Message);
+    _mockUserRepository.Verify(r => r.AddUserAsync(It.IsAny<User>()), Times.Never);
   }
 
   [Fact]

--- a/AuthService/src/AuthService/Configuration/PasswordPolicy.cs
+++ b/AuthService/src/AuthService/Configuration/PasswordPolicy.cs
@@ -1,0 +1,11 @@
+namespace AuthService.Configuration;
+
+public class PasswordPolicy
+{
+  public int MinimumLength { get; set; } = 8;
+  public bool RequireUppercase { get; set; } = true;
+  public bool RequireLowercase { get; set; } = true;
+  public bool RequireDigit { get; set; } = true;
+  public bool RequireSpecialCharacter { get; set; } = true;
+  public string SpecialCharacters { get; set; } = "!@#$%^&*()_+-=[]{}|;':\",./<>?";
+}

--- a/AuthService/src/AuthService/Program.cs
+++ b/AuthService/src/AuthService/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using AuthService.Configuration;
 using AuthService.Data;
 using AuthService.Middleware;
 using AuthService.Services;
@@ -40,6 +41,10 @@ builder.Services.AddDbContext<AuthDbContext>(options =>
 // Configure JWT authentication
 var jwtSettings = builder.Configuration.GetSection("JwtSettings");
 var secretKey = jwtSettings.GetValue<string>("SecretKey") ?? throw new ArgumentNullException("SecretKey", "SecretKey cannot be null");
+
+// Password policy
+builder.Services.Configure<PasswordPolicy>(builder.Configuration.GetSection("PasswordPolicy"));
+builder.Services.AddSingleton<IPasswordPolicyService, PasswordPolicyService>();
 
 // Register services
 builder.Services.AddScoped<IJwtTokenService, JwtTokenService>();

--- a/AuthService/src/AuthService/Services/ChangePasswordService.cs
+++ b/AuthService/src/AuthService/Services/ChangePasswordService.cs
@@ -10,19 +10,22 @@ public class ChangePasswordService : IChangePasswordService
   private readonly IJwtTokenService _jwtTokenService;
   private readonly IUserRoleClient _userRoleClient;
   private readonly ILogger<ChangePasswordService> _logger;
+  private readonly IPasswordPolicyService _passwordPolicyService;
 
   public ChangePasswordService(
       IUserRepository userRepository,
       IPasswordService passwordService,
       IJwtTokenService jwtTokenService,
       IUserRoleClient userRoleClient,
-      ILogger<ChangePasswordService> logger)
+      ILogger<ChangePasswordService> logger,
+      IPasswordPolicyService passwordPolicyService)
   {
     _userRepository = userRepository;
     _passwordService = passwordService;
     _jwtTokenService = jwtTokenService;
     _userRoleClient = userRoleClient;
     _logger = logger;
+    _passwordPolicyService = passwordPolicyService;
   }
 
   public async Task<ServiceResult> ChangePasswordAsync(Guid userId, string newPassword)
@@ -31,6 +34,10 @@ public class ChangePasswordService : IChangePasswordService
     {
       return ServiceResult.Failure("New password is required.", 400);
     }
+
+    var (isValid, errors) = _passwordPolicyService.Validate(newPassword);
+    if (!isValid)
+      return ServiceResult.Failure(string.Join(" ", errors), 400);
 
     var user = await _userRepository.GetUserByIdAsync(userId);
     if (user == null)

--- a/AuthService/src/AuthService/Services/ForgotPasswordService.cs
+++ b/AuthService/src/AuthService/Services/ForgotPasswordService.cs
@@ -10,17 +10,20 @@ public class ForgotPasswordService : IForgotPasswordService
   private readonly IPasswordResetTokenRepository _passwordResetTokenRepository;
   private readonly IPasswordService _passwordService;
   private readonly IEmailService _emailService;
+  private readonly IPasswordPolicyService _passwordPolicyService;
 
   public ForgotPasswordService(
       IUserRepository userRepository,
       IPasswordResetTokenRepository passwordResetTokenRepository,
       IPasswordService passwordService,
-      IEmailService emailService)
+      IEmailService emailService,
+      IPasswordPolicyService passwordPolicyService)
   {
     _userRepository = userRepository;
     _passwordResetTokenRepository = passwordResetTokenRepository;
     _passwordService = passwordService;
     _emailService = emailService;
+    _passwordPolicyService = passwordPolicyService;
   }
 
   public async Task<ServiceResult> ForgotPasswordAsync(string email)
@@ -55,6 +58,10 @@ public class ForgotPasswordService : IForgotPasswordService
 
   public async Task<ServiceResult> ResetPasswordAsync(string token, string newPassword)
   {
+    var (isValid, errors) = _passwordPolicyService.Validate(newPassword);
+    if (!isValid)
+      return ServiceResult.Failure(string.Join(" ", errors), 400);
+
     var resetToken = await _passwordResetTokenRepository.GetByTokenAsync(token);
 
     if (resetToken == null)

--- a/AuthService/src/AuthService/Services/IPasswordPolicyService.cs
+++ b/AuthService/src/AuthService/Services/IPasswordPolicyService.cs
@@ -1,0 +1,6 @@
+namespace AuthService.Services;
+
+public interface IPasswordPolicyService
+{
+  (bool IsValid, IReadOnlyList<string> Errors) Validate(string password);
+}

--- a/AuthService/src/AuthService/Services/InviteService.cs
+++ b/AuthService/src/AuthService/Services/InviteService.cs
@@ -14,6 +14,7 @@ public class InviteService : IInviteService
   private readonly IEmailService _emailService;
   private readonly IPublishEndpoint _publishEndpoint;
   private readonly IConfiguration _configuration;
+  private readonly IPasswordPolicyService _passwordPolicyService;
 
   public InviteService(
       IInviteTokenRepository inviteTokenRepository,
@@ -21,7 +22,8 @@ public class InviteService : IInviteService
       IPasswordService passwordService,
       IEmailService emailService,
       IPublishEndpoint publishEndpoint,
-      IConfiguration configuration)
+      IConfiguration configuration,
+      IPasswordPolicyService passwordPolicyService)
   {
     _inviteTokenRepository = inviteTokenRepository;
     _userRepository = userRepository;
@@ -29,6 +31,7 @@ public class InviteService : IInviteService
     _emailService = emailService;
     _publishEndpoint = publishEndpoint;
     _configuration = configuration;
+    _passwordPolicyService = passwordPolicyService;
   }
 
   public async Task<ServiceResult> CreateInviteAsync(string email, Guid adminUserId)
@@ -64,6 +67,10 @@ public class InviteService : IInviteService
 
   public async Task<ServiceResult> AcceptInviteAsync(string token, string password)
   {
+    var (isValid, errors) = _passwordPolicyService.Validate(password);
+    if (!isValid)
+      return ServiceResult.Failure(string.Join(" ", errors), 400);
+
     var inviteToken = await _inviteTokenRepository.GetByTokenAsync(token);
 
     if (inviteToken == null)

--- a/AuthService/src/AuthService/Services/PasswordPolicyService.cs
+++ b/AuthService/src/AuthService/Services/PasswordPolicyService.cs
@@ -1,0 +1,36 @@
+using AuthService.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace AuthService.Services;
+
+public class PasswordPolicyService : IPasswordPolicyService
+{
+  private readonly PasswordPolicy _policy;
+
+  public PasswordPolicyService(IOptions<PasswordPolicy> policy)
+  {
+    _policy = policy.Value;
+  }
+
+  public (bool IsValid, IReadOnlyList<string> Errors) Validate(string password)
+  {
+    var errors = new List<string>();
+
+    if (string.IsNullOrEmpty(password) || password.Length < _policy.MinimumLength)
+      errors.Add($"Password must be at least {_policy.MinimumLength} characters long.");
+
+    if (_policy.RequireUppercase && !password.Any(char.IsUpper))
+      errors.Add("Password must contain at least one uppercase letter.");
+
+    if (_policy.RequireLowercase && !password.Any(char.IsLower))
+      errors.Add("Password must contain at least one lowercase letter.");
+
+    if (_policy.RequireDigit && !password.Any(char.IsDigit))
+      errors.Add("Password must contain at least one digit.");
+
+    if (_policy.RequireSpecialCharacter && !password.Any(c => _policy.SpecialCharacters.Contains(c)))
+      errors.Add("Password must contain at least one special character.");
+
+    return (errors.Count == 0, errors);
+  }
+}

--- a/AuthService/src/AuthService/Services/RegistrationService.cs
+++ b/AuthService/src/AuthService/Services/RegistrationService.cs
@@ -10,15 +10,18 @@ public class RegistationService : IRegistrationService
   private readonly IUserRepository _userRepository;
   private readonly IPasswordService _passwordService;
   private readonly IPublishEndpoint _publishEndpoint;
+  private readonly IPasswordPolicyService _passwordPolicyService;
 
   public RegistationService(
       IUserRepository userRepository,
       IPasswordService passwordService,
-      IPublishEndpoint publishEndpoint)
+      IPublishEndpoint publishEndpoint,
+      IPasswordPolicyService passwordPolicyService)
   {
     _userRepository = userRepository;
     _passwordService = passwordService;
     _publishEndpoint = publishEndpoint;
+    _passwordPolicyService = passwordPolicyService;
   }
 
   public async Task<bool> ValidateEmailAsync(string email)
@@ -29,6 +32,10 @@ public class RegistationService : IRegistrationService
 
   public async Task<ServiceResult> RegisterUserAsync(string email, string password)
   {
+    var (isValid, errors) = _passwordPolicyService.Validate(password);
+    if (!isValid)
+      return ServiceResult.Failure(string.Join(" ", errors), 400);
+
     if (!await ValidateEmailAsync(email))
     {
       return ServiceResult.Failure("Email is already registered.", 409);

--- a/AuthService/src/AuthService/appsettings.json
+++ b/AuthService/src/AuthService/appsettings.json
@@ -21,6 +21,14 @@
     "Host": "rabbitmq",
     "VirtualHost": "/"
   },
+  "PasswordPolicy": {
+    "MinimumLength": 8,
+    "RequireUppercase": true,
+    "RequireLowercase": true,
+    "RequireDigit": true,
+    "RequireSpecialCharacter": true,
+    "SpecialCharacters": "!@#$%^&*()_+-=[]{}|;':\",./<>?"
+  },
   "InviteSettings": {
     "TokenExpiryHours": 48,
     "FrontendUrl": "http://localhost:3000"


### PR DESCRIPTION
Enforce a configurable password policy at AuthService.

- Minimum length
- Complexity rules (uppercase, lowercase, digit, special character)
- Policy configurable via `appsettings.json`
- Applied at registration, invite acceptance, and password reset

Closes #38

Generated with [Claude Code](https://claude.ai/code)