### PR TITLE
feat: add identity audit log for admin actions

### DIFF
--- a/UserManagementService/src/UserManagementService.Tests/Controllers/AdminControllerTests.cs
+++ b/UserManagementService/src/UserManagementService.Tests/Controllers/AdminControllerTests.cs
@@ -52,7 +52,7 @@ public class AdminControllerTests
   {
     var userId = Guid.NewGuid();
     var request = new UpdateUserRoleRequest { Role = UserRole.Admin };
-    _serviceMock.Setup(s => s.UpdateUserRoleAsync(userId, UserRole.Admin))
+    _serviceMock.Setup(s => s.UpdateUserRoleAsync(userId, UserRole.Admin, It.IsAny<Guid>()))
       .ReturnsAsync(ServiceResult.Success(new AdminUserResponse { UserId = userId, Role = UserRole.Admin }));
 
     var result = await _sut.UpdateUserRole(userId, request);
@@ -66,7 +66,7 @@ public class AdminControllerTests
   {
     var userId = Guid.NewGuid();
     var request = new UpdateUserRoleRequest { Role = UserRole.Admin };
-    _serviceMock.Setup(s => s.UpdateUserRoleAsync(userId, UserRole.Admin))
+    _serviceMock.Setup(s => s.UpdateUserRoleAsync(userId, UserRole.Admin, It.IsAny<Guid>()))
       .ReturnsAsync(ServiceResult.Failure("User profile not found.", 404));
 
     var result = await _sut.UpdateUserRole(userId, request);
@@ -80,7 +80,7 @@ public class AdminControllerTests
   {
     var userId = Guid.NewGuid();
     var request = new UpdateUserRoleRequest { Role = UserRole.Admin };
-    _serviceMock.Setup(s => s.UpdateUserRoleAsync(userId, UserRole.Admin)).ThrowsAsync(new Exception());
+    _serviceMock.Setup(s => s.UpdateUserRoleAsync(userId, UserRole.Admin, It.IsAny<Guid>())).ThrowsAsync(new Exception());
 
     var result = await _sut.UpdateUserRole(userId, request);
 
@@ -93,7 +93,7 @@ public class AdminControllerTests
   {
     var userId = Guid.NewGuid();
     var request = new UpdateUserRoleRequest { Role = UserRole.Unassigned };
-    _serviceMock.Setup(s => s.UpdateUserRoleAsync(userId, UserRole.Unassigned))
+    _serviceMock.Setup(s => s.UpdateUserRoleAsync(userId, UserRole.Unassigned, It.IsAny<Guid>()))
       .ReturnsAsync(ServiceResult.Failure("Cannot set role to Unassigned."));
 
     var result = await _sut.UpdateUserRole(userId, request);
@@ -109,7 +109,7 @@ public class AdminControllerTests
   {
     var userId = Guid.NewGuid();
     var request = new SetUserActiveRequest { IsActive = false };
-    _serviceMock.Setup(s => s.SetUserActiveAsync(userId, false))
+    _serviceMock.Setup(s => s.SetUserActiveAsync(userId, false, It.IsAny<Guid>()))
       .ReturnsAsync(ServiceResult.Success(new AdminUserResponse { UserId = userId, IsActive = false }));
 
     var result = await _sut.SetUserActive(userId, request);
@@ -123,7 +123,7 @@ public class AdminControllerTests
   {
     var userId = Guid.NewGuid();
     var request = new SetUserActiveRequest { IsActive = false };
-    _serviceMock.Setup(s => s.SetUserActiveAsync(userId, false))
+    _serviceMock.Setup(s => s.SetUserActiveAsync(userId, false, It.IsAny<Guid>()))
       .ReturnsAsync(ServiceResult.Failure("User profile not found.", 404));
 
     var result = await _sut.SetUserActive(userId, request);
@@ -137,7 +137,7 @@ public class AdminControllerTests
   {
     var userId = Guid.NewGuid();
     var request = new SetUserActiveRequest { IsActive = false };
-    _serviceMock.Setup(s => s.SetUserActiveAsync(userId, false)).ThrowsAsync(new Exception());
+    _serviceMock.Setup(s => s.SetUserActiveAsync(userId, false, It.IsAny<Guid>())).ThrowsAsync(new Exception());
 
     var result = await _sut.SetUserActive(userId, request);
 

--- a/UserManagementService/src/UserManagementService.Tests/Controllers/UsersControllerTests.cs
+++ b/UserManagementService/src/UserManagementService.Tests/Controllers/UsersControllerTests.cs
@@ -13,12 +13,13 @@ namespace UserManagementService.Tests.Controllers;
 public class UsersControllerTests
 {
   private readonly Mock<IUserProfileService> _serviceMock = new();
+  private readonly Mock<IAuditLogService> _auditLogServiceMock = new();
   private readonly Mock<ILogger<UsersController>> _loggerMock = new();
   private readonly UsersController _sut;
 
   public UsersControllerTests()
   {
-    _sut = new UsersController(_serviceMock.Object, _loggerMock.Object);
+    _sut = new UsersController(_serviceMock.Object, _auditLogServiceMock.Object, _loggerMock.Object);
   }
 
   // ── CreateUserProfile ─────────────────────────────────────────────────────
@@ -169,7 +170,7 @@ public class UsersControllerTests
   {
     var userId = Guid.NewGuid();
     var request = new SetUserActiveRequest { IsActive = false };
-    _serviceMock.Setup(s => s.SetUserActiveAsync(userId, false))
+    _serviceMock.Setup(s => s.SetUserActiveAsync(userId, false, It.IsAny<Guid>()))
       .ReturnsAsync(ServiceResult.Success(new AdminUserResponse { UserId = userId, IsActive = false }));
 
     var result = await _sut.PatchUserStatus(userId, request);
@@ -183,7 +184,7 @@ public class UsersControllerTests
   {
     var userId = Guid.NewGuid();
     var request = new SetUserActiveRequest { IsActive = true };
-    _serviceMock.Setup(s => s.SetUserActiveAsync(userId, true))
+    _serviceMock.Setup(s => s.SetUserActiveAsync(userId, true, It.IsAny<Guid>()))
       .ReturnsAsync(ServiceResult.Success(new AdminUserResponse { UserId = userId, IsActive = true }));
 
     var result = await _sut.PatchUserStatus(userId, request);
@@ -197,7 +198,7 @@ public class UsersControllerTests
   {
     var userId = Guid.NewGuid();
     var request = new SetUserActiveRequest { IsActive = false };
-    _serviceMock.Setup(s => s.SetUserActiveAsync(userId, false))
+    _serviceMock.Setup(s => s.SetUserActiveAsync(userId, false, It.IsAny<Guid>()))
       .ReturnsAsync(ServiceResult.Failure("User profile not found.", 404));
 
     var result = await _sut.PatchUserStatus(userId, request);
@@ -211,7 +212,7 @@ public class UsersControllerTests
   {
     var userId = Guid.NewGuid();
     var request = new SetUserActiveRequest { IsActive = false };
-    _serviceMock.Setup(s => s.SetUserActiveAsync(userId, false)).ThrowsAsync(new Exception());
+    _serviceMock.Setup(s => s.SetUserActiveAsync(userId, false, It.IsAny<Guid>())).ThrowsAsync(new Exception());
 
     var result = await _sut.PatchUserStatus(userId, request);
 
@@ -226,7 +227,7 @@ public class UsersControllerTests
   {
     var userId = Guid.NewGuid();
     var request = new UpdateUserRoleRequest { Role = UserRole.Admin };
-    _serviceMock.Setup(s => s.UpdateUserRoleAsync(userId, UserRole.Admin))
+    _serviceMock.Setup(s => s.UpdateUserRoleAsync(userId, UserRole.Admin, It.IsAny<Guid>()))
       .ReturnsAsync(ServiceResult.Success(new AdminUserResponse { UserId = userId, Role = UserRole.Admin }));
 
     var result = await _sut.PatchUserRole(userId, request);
@@ -251,7 +252,7 @@ public class UsersControllerTests
   {
     var userId = Guid.NewGuid();
     var request = new UpdateUserRoleRequest { Role = UserRole.Unassigned };
-    _serviceMock.Setup(s => s.UpdateUserRoleAsync(userId, UserRole.Unassigned))
+    _serviceMock.Setup(s => s.UpdateUserRoleAsync(userId, UserRole.Unassigned, It.IsAny<Guid>()))
       .ReturnsAsync(ServiceResult.Failure("Cannot set role to Unassigned. Use Member, SalesRep, Manager, or Admin."));
 
     var result = await _sut.PatchUserRole(userId, request);
@@ -265,7 +266,7 @@ public class UsersControllerTests
   {
     var userId = Guid.NewGuid();
     var request = new UpdateUserRoleRequest { Role = UserRole.Member };
-    _serviceMock.Setup(s => s.UpdateUserRoleAsync(userId, UserRole.Member))
+    _serviceMock.Setup(s => s.UpdateUserRoleAsync(userId, UserRole.Member, It.IsAny<Guid>()))
       .ReturnsAsync(ServiceResult.Failure("User profile not found.", 404));
 
     var result = await _sut.PatchUserRole(userId, request);
@@ -279,7 +280,7 @@ public class UsersControllerTests
   {
     var userId = Guid.NewGuid();
     var request = new UpdateUserRoleRequest { Role = UserRole.Member };
-    _serviceMock.Setup(s => s.UpdateUserRoleAsync(userId, UserRole.Member)).ThrowsAsync(new Exception());
+    _serviceMock.Setup(s => s.UpdateUserRoleAsync(userId, UserRole.Member, It.IsAny<Guid>())).ThrowsAsync(new Exception());
 
     var result = await _sut.PatchUserRole(userId, request);
 
@@ -293,7 +294,7 @@ public class UsersControllerTests
   public async Task ResendInvite_ReturnsOk_WhenSuccessful()
   {
     var userId = Guid.NewGuid();
-    _serviceMock.Setup(s => s.ResendInviteAsync(userId))
+    _serviceMock.Setup(s => s.ResendInviteAsync(userId, It.IsAny<Guid>()))
       .ReturnsAsync(ServiceResult.Success(new { userId, email = "user@example.com" }));
 
     var result = await _sut.ResendInvite(userId);
@@ -306,7 +307,7 @@ public class UsersControllerTests
   public async Task ResendInvite_Returns404_WhenUserNotFound()
   {
     var userId = Guid.NewGuid();
-    _serviceMock.Setup(s => s.ResendInviteAsync(userId))
+    _serviceMock.Setup(s => s.ResendInviteAsync(userId, It.IsAny<Guid>()))
       .ReturnsAsync(ServiceResult.Failure("User profile not found.", 404));
 
     var result = await _sut.ResendInvite(userId);
@@ -319,7 +320,7 @@ public class UsersControllerTests
   public async Task ResendInvite_Returns400_WhenNoPendingInvite()
   {
     var userId = Guid.NewGuid();
-    _serviceMock.Setup(s => s.ResendInviteAsync(userId))
+    _serviceMock.Setup(s => s.ResendInviteAsync(userId, It.IsAny<Guid>()))
       .ReturnsAsync(ServiceResult.Failure("User does not have a pending invite."));
 
     var result = await _sut.ResendInvite(userId);
@@ -332,9 +333,33 @@ public class UsersControllerTests
   public async Task ResendInvite_Returns500_OnException()
   {
     var userId = Guid.NewGuid();
-    _serviceMock.Setup(s => s.ResendInviteAsync(userId)).ThrowsAsync(new Exception());
+    _serviceMock.Setup(s => s.ResendInviteAsync(userId, It.IsAny<Guid>())).ThrowsAsync(new Exception());
 
     var result = await _sut.ResendInvite(userId);
+
+    var obj = result.Should().BeOfType<ObjectResult>().Subject;
+    obj.StatusCode.Should().Be(500);
+  }
+
+  // ── GetAuditLog ───────────────────────────────────────────────────────────
+
+  [Fact]
+  public async Task GetAuditLog_ReturnsOk_WithEntries()
+  {
+    _auditLogServiceMock.Setup(s => s.GetAuditLogsAsync())
+      .ReturnsAsync(new List<AuditLogResponse>());
+
+    var result = await _sut.GetAuditLog();
+
+    result.Should().BeOfType<OkObjectResult>();
+  }
+
+  [Fact]
+  public async Task GetAuditLog_Returns500_OnException()
+  {
+    _auditLogServiceMock.Setup(s => s.GetAuditLogsAsync()).ThrowsAsync(new Exception());
+
+    var result = await _sut.GetAuditLog();
 
     var obj = result.Should().BeOfType<ObjectResult>().Subject;
     obj.StatusCode.Should().Be(500);

--- a/UserManagementService/src/UserManagementService.Tests/Services/AdminServiceTests.cs
+++ b/UserManagementService/src/UserManagementService.Tests/Services/AdminServiceTests.cs
@@ -5,6 +5,7 @@ using UserManagementService.Models;
 using UserManagementService.Models.DTOs;
 using UserManagementService.Repository;
 using UserManagementService.Services;
+using AuditAction = UserManagementService.Models.AuditAction;
 
 namespace UserManagementService.Tests.Services;
 
@@ -12,7 +13,9 @@ public class AdminServiceTests
 {
   private readonly Mock<IUserProfileRepository> _mockRepository;
   private readonly Mock<IEmailService> _mockEmailService;
+  private readonly Mock<IAuditLogService> _mockAuditLogService;
   private readonly UserProfileService _service;
+  private readonly Guid _actorUserId = Guid.NewGuid();
 
   public AdminServiceTests()
   {
@@ -20,7 +23,10 @@ public class AdminServiceTests
     _mockEmailService = new Mock<IEmailService>();
     _mockEmailService.Setup(e => e.SendInviteEmailAsync(It.IsAny<string>(), It.IsAny<string>()))
       .Returns(Task.CompletedTask);
-    _service = new UserProfileService(_mockRepository.Object, _mockEmailService.Object);
+    _mockAuditLogService = new Mock<IAuditLogService>();
+    _mockAuditLogService.Setup(a => a.LogActionAsync(It.IsAny<AuditAction>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string?>()))
+      .Returns(Task.CompletedTask);
+    _service = new UserProfileService(_mockRepository.Object, _mockEmailService.Object, _mockAuditLogService.Object);
   }
 
   // ── GetAllUsersAsync ──────────────────────────────────────────────────────
@@ -56,7 +62,7 @@ public class AdminServiceTests
     _mockRepository.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync(profile);
     _mockRepository.Setup(r => r.UpdateAsync(It.IsAny<UserProfile>())).Returns(Task.CompletedTask);
 
-    var result = await _service.UpdateUserRoleAsync(userId, UserRole.Admin);
+    var result = await _service.UpdateUserRoleAsync(userId, UserRole.Admin, _actorUserId);
 
     result.IsSuccess.Should().BeTrue();
     result.StatusCode.Should().Be(200);
@@ -70,7 +76,7 @@ public class AdminServiceTests
     var userId = Guid.NewGuid();
     _mockRepository.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync((UserProfile?)null);
 
-    var result = await _service.UpdateUserRoleAsync(userId, UserRole.Admin);
+    var result = await _service.UpdateUserRoleAsync(userId, UserRole.Admin, _actorUserId);
 
     result.IsSuccess.Should().BeFalse();
     result.StatusCode.Should().Be(404);
@@ -84,7 +90,7 @@ public class AdminServiceTests
     _mockRepository.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync(profile);
     _mockRepository.Setup(r => r.UpdateAsync(It.IsAny<UserProfile>())).Returns(Task.CompletedTask);
 
-    var result = await _service.UpdateUserRoleAsync(userId, UserRole.SalesRep);
+    var result = await _service.UpdateUserRoleAsync(userId, UserRole.SalesRep, _actorUserId);
 
     result.IsSuccess.Should().BeTrue();
     result.StatusCode.Should().Be(200);
@@ -100,7 +106,7 @@ public class AdminServiceTests
     _mockRepository.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync(profile);
     _mockRepository.Setup(r => r.UpdateAsync(It.IsAny<UserProfile>())).Returns(Task.CompletedTask);
 
-    var result = await _service.UpdateUserRoleAsync(userId, UserRole.Manager);
+    var result = await _service.UpdateUserRoleAsync(userId, UserRole.Manager, _actorUserId);
 
     result.IsSuccess.Should().BeTrue();
     result.StatusCode.Should().Be(200);
@@ -118,7 +124,7 @@ public class AdminServiceTests
     _mockRepository.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync(profile);
     _mockRepository.Setup(r => r.UpdateAsync(It.IsAny<UserProfile>())).Returns(Task.CompletedTask);
 
-    var result = await _service.SetUserActiveAsync(userId, false);
+    var result = await _service.SetUserActiveAsync(userId, false, _actorUserId);
 
     result.IsSuccess.Should().BeTrue();
     result.StatusCode.Should().Be(200);
@@ -132,7 +138,7 @@ public class AdminServiceTests
     var userId = Guid.NewGuid();
     _mockRepository.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync((UserProfile?)null);
 
-    var result = await _service.SetUserActiveAsync(userId, false);
+    var result = await _service.SetUserActiveAsync(userId, false, _actorUserId);
 
     result.IsSuccess.Should().BeFalse();
     result.StatusCode.Should().Be(404);

--- a/UserManagementService/src/UserManagementService.Tests/Services/AuditLogServiceTests.cs
+++ b/UserManagementService/src/UserManagementService.Tests/Services/AuditLogServiceTests.cs
@@ -1,0 +1,111 @@
+using FluentAssertions;
+using Moq;
+using UserManagementService.Models;
+using UserManagementService.Models.DTOs;
+using UserManagementService.Repository;
+using UserManagementService.Services;
+
+namespace UserManagementService.Tests.Services;
+
+public class AuditLogServiceTests
+{
+  private readonly Mock<IAuditLogRepository> _mockRepository;
+  private readonly AuditLogService _service;
+
+  public AuditLogServiceTests()
+  {
+    _mockRepository = new Mock<IAuditLogRepository>();
+    _mockRepository.Setup(r => r.AddAsync(It.IsAny<AuditLog>())).Returns(Task.CompletedTask);
+    _service = new AuditLogService(_mockRepository.Object);
+  }
+
+  [Fact]
+  public async Task LogActionAsync_CreatesEntryWithCorrectFields()
+  {
+    var actorId = Guid.NewGuid();
+    var targetId = Guid.NewGuid();
+    AuditLog? captured = null;
+    _mockRepository.Setup(r => r.AddAsync(It.IsAny<AuditLog>()))
+      .Callback<AuditLog>(e => captured = e)
+      .Returns(Task.CompletedTask);
+
+    var before = DateTime.UtcNow;
+    await _service.LogActionAsync(AuditAction.RoleChanged, actorId, targetId, "Member to Admin");
+
+    captured.Should().NotBeNull();
+    captured!.Action.Should().Be(AuditAction.RoleChanged);
+    captured.ActorUserId.Should().Be(actorId);
+    captured.TargetUserId.Should().Be(targetId);
+    captured.Details.Should().Be("Member to Admin");
+    captured.Timestamp.Should().BeOnOrAfter(before);
+    captured.Id.Should().NotBeEmpty();
+  }
+
+  [Fact]
+  public async Task LogActionAsync_WithNullDetails_StoresNullDetails()
+  {
+    var actorId = Guid.NewGuid();
+    var targetId = Guid.NewGuid();
+    AuditLog? captured = null;
+    _mockRepository.Setup(r => r.AddAsync(It.IsAny<AuditLog>()))
+      .Callback<AuditLog>(e => captured = e)
+      .Returns(Task.CompletedTask);
+
+    await _service.LogActionAsync(AuditAction.AccountDeactivated, actorId, targetId);
+
+    captured!.Details.Should().BeNull();
+  }
+
+  [Fact]
+  public async Task GetAuditLogsAsync_ReturnsMappedResponses()
+  {
+    var entries = new List<AuditLog>
+    {
+      new()
+      {
+        Id = Guid.NewGuid(),
+        Action = AuditAction.RoleChanged,
+        ActorUserId = Guid.NewGuid(),
+        TargetUserId = Guid.NewGuid(),
+        Details = "Member to Admin",
+        Timestamp = DateTime.UtcNow
+      },
+      new()
+      {
+        Id = Guid.NewGuid(),
+        Action = AuditAction.AccountDeactivated,
+        ActorUserId = Guid.NewGuid(),
+        TargetUserId = Guid.NewGuid(),
+        Details = null,
+        Timestamp = DateTime.UtcNow.AddMinutes(-5)
+      }
+    };
+    _mockRepository.Setup(r => r.GetAllAsync()).ReturnsAsync(entries);
+
+    var result = await _service.GetAuditLogsAsync();
+
+    result.Should().HaveCount(2);
+    result[0].Action.Should().Be("RoleChanged");
+    result[0].Details.Should().Be("Member to Admin");
+    result[1].Action.Should().Be("AccountDeactivated");
+    result[1].Details.Should().BeNull();
+  }
+
+  [Fact]
+  public async Task GetAuditLogsAsync_WhenNoEntries_ReturnsEmptyList()
+  {
+    _mockRepository.Setup(r => r.GetAllAsync()).ReturnsAsync(new List<AuditLog>());
+
+    var result = await _service.GetAuditLogsAsync();
+
+    result.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task LogActionAsync_CallsRepositoryAddAsync()
+  {
+    await _service.LogActionAsync(AuditAction.InviteSent, Guid.NewGuid(), Guid.NewGuid());
+
+    _mockRepository.Verify(r => r.AddAsync(It.IsAny<AuditLog>()), Times.Once);
+  }
+}

--- a/UserManagementService/src/UserManagementService.Tests/Services/UserProfileServiceTests.cs
+++ b/UserManagementService/src/UserManagementService.Tests/Services/UserProfileServiceTests.cs
@@ -6,6 +6,7 @@ using UserManagementService.Models;
 using UserManagementService.Models.DTOs;
 using UserManagementService.Repository;
 using UserManagementService.Services;
+using AuditAction = UserManagementService.Models.AuditAction;
 
 namespace UserManagementService.Tests.Services;
 
@@ -13,7 +14,9 @@ public class UserProfileServiceTests
 {
   private readonly Mock<IUserProfileRepository> _mockRepository;
   private readonly Mock<IEmailService> _mockEmailService;
+  private readonly Mock<IAuditLogService> _mockAuditLogService;
   private readonly UserProfileService _service;
+  private readonly Guid _actorUserId = Guid.NewGuid();
 
   public UserProfileServiceTests()
   {
@@ -21,7 +24,10 @@ public class UserProfileServiceTests
     _mockEmailService = new Mock<IEmailService>();
     _mockEmailService.Setup(e => e.SendInviteEmailAsync(It.IsAny<string>(), It.IsAny<string>()))
       .Returns(Task.CompletedTask);
-    _service = new UserProfileService(_mockRepository.Object, _mockEmailService.Object);
+    _mockAuditLogService = new Mock<IAuditLogService>();
+    _mockAuditLogService.Setup(a => a.LogActionAsync(It.IsAny<AuditAction>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string?>()))
+      .Returns(Task.CompletedTask);
+    _service = new UserProfileService(_mockRepository.Object, _mockEmailService.Object, _mockAuditLogService.Object);
   }
 
   [Fact]
@@ -51,7 +57,7 @@ public class UserProfileServiceTests
   {
     var userId = Guid.NewGuid();
 
-    var result = await _service.UpdateUserRoleAsync(userId, UserRole.Unassigned);
+    var result = await _service.UpdateUserRoleAsync(userId, UserRole.Unassigned, _actorUserId);
 
     result.IsSuccess.Should().BeFalse();
     result.StatusCode.Should().Be(400);
@@ -66,7 +72,7 @@ public class UserProfileServiceTests
     _mockRepository.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync(profile);
     _mockRepository.Setup(r => r.UpdateAsync(It.IsAny<UserProfile>())).Returns(Task.CompletedTask);
 
-    var result = await _service.UpdateUserRoleAsync(userId, UserRole.Member);
+    var result = await _service.UpdateUserRoleAsync(userId, UserRole.Member, _actorUserId);
 
     result.IsSuccess.Should().BeTrue();
     result.StatusCode.Should().Be(200);
@@ -139,7 +145,7 @@ public class UserProfileServiceTests
     _mockRepository.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync(profile);
     _mockRepository.Setup(r => r.UpdateAsync(It.IsAny<UserProfile>())).Returns(Task.CompletedTask);
 
-    var result = await _service.SetUserActiveAsync(userId, false);
+    var result = await _service.SetUserActiveAsync(userId, false, _actorUserId);
 
     result.IsSuccess.Should().BeTrue();
     result.StatusCode.Should().Be(200);
@@ -153,7 +159,7 @@ public class UserProfileServiceTests
     var userId = Guid.NewGuid();
     _mockRepository.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync((UserProfile?)null);
 
-    var result = await _service.SetUserActiveAsync(userId, false);
+    var result = await _service.SetUserActiveAsync(userId, false, _actorUserId);
 
     result.IsSuccess.Should().BeFalse();
     result.StatusCode.Should().Be(404);
@@ -167,7 +173,7 @@ public class UserProfileServiceTests
     var userId = Guid.NewGuid();
     _mockRepository.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync((UserProfile?)null);
 
-    var result = await _service.ResendInviteAsync(userId);
+    var result = await _service.ResendInviteAsync(userId, _actorUserId);
 
     result.IsSuccess.Should().BeFalse();
     result.StatusCode.Should().Be(404);
@@ -180,7 +186,7 @@ public class UserProfileServiceTests
     var profile = new UserProfile { UserId = userId, Email = "user@example.com", InviteToken = null };
     _mockRepository.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync(profile);
 
-    var result = await _service.ResendInviteAsync(userId);
+    var result = await _service.ResendInviteAsync(userId, _actorUserId);
 
     result.IsSuccess.Should().BeFalse();
     result.StatusCode.Should().Be(400);
@@ -201,7 +207,7 @@ public class UserProfileServiceTests
     _mockRepository.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync(profile);
     _mockRepository.Setup(r => r.UpdateAsync(It.IsAny<UserProfile>())).Returns(Task.CompletedTask);
 
-    var result = await _service.ResendInviteAsync(userId);
+    var result = await _service.ResendInviteAsync(userId, _actorUserId);
 
     result.IsSuccess.Should().BeTrue();
     result.StatusCode.Should().Be(200);
@@ -229,7 +235,7 @@ public class UserProfileServiceTests
     _mockRepository.Setup(r => r.UpdateAsync(It.IsAny<UserProfile>())).Returns(Task.CompletedTask);
 
     var before = DateTime.UtcNow;
-    await _service.ResendInviteAsync(userId);
+    await _service.ResendInviteAsync(userId, _actorUserId);
 
     profile.InvitePendingAt.Should().NotBeNull();
     profile.InvitePendingAt!.Value.Should().BeOnOrAfter(before);

--- a/UserManagementService/src/UserManagementService/Controllers/AdminController.cs
+++ b/UserManagementService/src/UserManagementService/Controllers/AdminController.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using UserManagementService.Models.DTOs;
@@ -19,6 +20,9 @@ public class AdminController : ControllerBase
     _logger = logger;
   }
 
+  private Guid GetActorUserId() =>
+    Guid.TryParse(User.FindFirstValue("UserId"), out var id) ? id : Guid.Empty;
+
   [HttpGet("users")]
   public async Task<IActionResult> GetAllUsers()
   {
@@ -39,7 +43,7 @@ public class AdminController : ControllerBase
   {
     try
     {
-      var result = await _userProfileService.UpdateUserRoleAsync(userId, request.Role);
+      var result = await _userProfileService.UpdateUserRoleAsync(userId, request.Role, GetActorUserId());
       return StatusCode(result.StatusCode, result.Data ?? result.Message);
     }
     catch (Exception ex)
@@ -54,7 +58,7 @@ public class AdminController : ControllerBase
   {
     try
     {
-      var result = await _userProfileService.SetUserActiveAsync(userId, request.IsActive);
+      var result = await _userProfileService.SetUserActiveAsync(userId, request.IsActive, GetActorUserId());
       return StatusCode(result.StatusCode, result.Data ?? result.Message);
     }
     catch (Exception ex)

--- a/UserManagementService/src/UserManagementService/Controllers/UsersController.cs
+++ b/UserManagementService/src/UserManagementService/Controllers/UsersController.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SharedLibrary.DTOs;
@@ -12,13 +13,18 @@ namespace UserManagementService.Controllers;
 public class UsersController : ControllerBase
 {
   private readonly IUserProfileService _userProfileService;
+  private readonly IAuditLogService _auditLogService;
   private readonly ILogger<UsersController> _logger;
 
-  public UsersController(IUserProfileService userProfileService, ILogger<UsersController> logger)
+  public UsersController(IUserProfileService userProfileService, IAuditLogService auditLogService, ILogger<UsersController> logger)
   {
     _userProfileService = userProfileService;
+    _auditLogService = auditLogService;
     _logger = logger;
   }
+
+  private Guid GetActorUserId() =>
+    Guid.TryParse(User.FindFirstValue("UserId"), out var id) ? id : Guid.Empty;
 
   [HttpPost]
   public async Task<IActionResult> CreateUserProfile([FromBody] CreateUserProfileRequest request)
@@ -89,7 +95,7 @@ public class UsersController : ControllerBase
   {
     try
     {
-      var result = await _userProfileService.SetUserActiveAsync(userId, request.IsActive);
+      var result = await _userProfileService.SetUserActiveAsync(userId, request.IsActive, GetActorUserId());
       return StatusCode(result.StatusCode, result.Data ?? result.Message);
     }
     catch (Exception ex)
@@ -108,7 +114,7 @@ public class UsersController : ControllerBase
 
     try
     {
-      var result = await _userProfileService.UpdateUserRoleAsync(userId, request.Role);
+      var result = await _userProfileService.UpdateUserRoleAsync(userId, request.Role, GetActorUserId());
       return StatusCode(result.StatusCode, result.Data ?? result.Message);
     }
     catch (Exception ex)
@@ -124,13 +130,29 @@ public class UsersController : ControllerBase
   {
     try
     {
-      var result = await _userProfileService.ResendInviteAsync(userId);
+      var result = await _userProfileService.ResendInviteAsync(userId, GetActorUserId());
       return StatusCode(result.StatusCode, result.Data ?? result.Message);
     }
     catch (Exception ex)
     {
       _logger.LogError(ex, "Error resending invite for user {UserId}", userId);
       return StatusCode(500, "An error occurred while resending the invite.");
+    }
+  }
+
+  [HttpGet("audit")]
+  [Authorize(Policy = "admin")]
+  public async Task<IActionResult> GetAuditLog()
+  {
+    try
+    {
+      var entries = await _auditLogService.GetAuditLogsAsync();
+      return Ok(entries);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Error retrieving audit log");
+      return StatusCode(500, "An error occurred while retrieving the audit log.");
     }
   }
 }

--- a/UserManagementService/src/UserManagementService/Data/UserManagementDbContext.cs
+++ b/UserManagementService/src/UserManagementService/Data/UserManagementDbContext.cs
@@ -8,4 +8,5 @@ public class UserManagementDbContext : DbContext
   public UserManagementDbContext(DbContextOptions<UserManagementDbContext> options) : base(options) { }
 
   public DbSet<UserProfile> UserProfiles => Set<UserProfile>();
+  public DbSet<AuditLog> AuditLogs => Set<AuditLog>();
 }

--- a/UserManagementService/src/UserManagementService/Models/AuditAction.cs
+++ b/UserManagementService/src/UserManagementService/Models/AuditAction.cs
@@ -1,0 +1,9 @@
+namespace UserManagementService.Models;
+
+public enum AuditAction
+{
+  RoleChanged,
+  AccountDeactivated,
+  AccountActivated,
+  InviteSent
+}

--- a/UserManagementService/src/UserManagementService/Models/AuditLog.cs
+++ b/UserManagementService/src/UserManagementService/Models/AuditLog.cs
@@ -1,0 +1,11 @@
+namespace UserManagementService.Models;
+
+public class AuditLog
+{
+  public Guid Id { get; set; }
+  public AuditAction Action { get; set; }
+  public Guid ActorUserId { get; set; }
+  public Guid TargetUserId { get; set; }
+  public string? Details { get; set; }
+  public DateTime Timestamp { get; set; }
+}

--- a/UserManagementService/src/UserManagementService/Models/DTOs/AuditLogResponse.cs
+++ b/UserManagementService/src/UserManagementService/Models/DTOs/AuditLogResponse.cs
@@ -1,0 +1,13 @@
+using UserManagementService.Models;
+
+namespace UserManagementService.Models.DTOs;
+
+public class AuditLogResponse
+{
+  public Guid Id { get; set; }
+  public string Action { get; set; } = string.Empty;
+  public Guid ActorUserId { get; set; }
+  public Guid TargetUserId { get; set; }
+  public string? Details { get; set; }
+  public DateTime Timestamp { get; set; }
+}

--- a/UserManagementService/src/UserManagementService/Program.cs
+++ b/UserManagementService/src/UserManagementService/Program.cs
@@ -36,7 +36,9 @@ builder.Services.AddDbContext<UserManagementDbContext>(options =>
   options.UseNpgsql(builder.Configuration.GetConnectionString("UserManagementDbConnection")));
 
 builder.Services.AddScoped<IUserProfileRepository, UserProfileRepository>();
+builder.Services.AddScoped<IAuditLogRepository, AuditLogRepository>();
 builder.Services.AddScoped<IUserProfileService, UserProfileService>();
+builder.Services.AddScoped<IAuditLogService, AuditLogService>();
 builder.Services.AddSingleton<IEmailService, EmailService>();
 
 // Configure JWT authentication (validates tokens issued by AuthService)

--- a/UserManagementService/src/UserManagementService/Repository/AuditLogRepository.cs
+++ b/UserManagementService/src/UserManagementService/Repository/AuditLogRepository.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore;
+using UserManagementService.Data;
+using UserManagementService.Models;
+
+namespace UserManagementService.Repository;
+
+public class AuditLogRepository : IAuditLogRepository
+{
+  private readonly UserManagementDbContext _context;
+
+  public AuditLogRepository(UserManagementDbContext context)
+  {
+    _context = context;
+  }
+
+  public async Task AddAsync(AuditLog entry)
+  {
+    _context.AuditLogs.Add(entry);
+    await _context.SaveChangesAsync();
+  }
+
+  public async Task<List<AuditLog>> GetAllAsync() =>
+    await _context.AuditLogs
+      .OrderByDescending(a => a.Timestamp)
+      .ToListAsync();
+}

--- a/UserManagementService/src/UserManagementService/Repository/IAuditLogRepository.cs
+++ b/UserManagementService/src/UserManagementService/Repository/IAuditLogRepository.cs
@@ -1,0 +1,9 @@
+using UserManagementService.Models;
+
+namespace UserManagementService.Repository;
+
+public interface IAuditLogRepository
+{
+  Task AddAsync(AuditLog entry);
+  Task<List<AuditLog>> GetAllAsync();
+}

--- a/UserManagementService/src/UserManagementService/Services/AuditLogService.cs
+++ b/UserManagementService/src/UserManagementService/Services/AuditLogService.cs
@@ -1,0 +1,44 @@
+using UserManagementService.Models;
+using UserManagementService.Models.DTOs;
+using UserManagementService.Repository;
+
+namespace UserManagementService.Services;
+
+public class AuditLogService : IAuditLogService
+{
+  private readonly IAuditLogRepository _repository;
+
+  public AuditLogService(IAuditLogRepository repository)
+  {
+    _repository = repository;
+  }
+
+  public async Task LogActionAsync(AuditAction action, Guid actorUserId, Guid targetUserId, string? details = null)
+  {
+    var entry = new AuditLog
+    {
+      Id = Guid.NewGuid(),
+      Action = action,
+      ActorUserId = actorUserId,
+      TargetUserId = targetUserId,
+      Details = details,
+      Timestamp = DateTime.UtcNow
+    };
+
+    await _repository.AddAsync(entry);
+  }
+
+  public async Task<List<AuditLogResponse>> GetAuditLogsAsync()
+  {
+    var entries = await _repository.GetAllAsync();
+    return entries.Select(e => new AuditLogResponse
+    {
+      Id = e.Id,
+      Action = e.Action.ToString(),
+      ActorUserId = e.ActorUserId,
+      TargetUserId = e.TargetUserId,
+      Details = e.Details,
+      Timestamp = e.Timestamp
+    }).ToList();
+  }
+}

--- a/UserManagementService/src/UserManagementService/Services/IAuditLogService.cs
+++ b/UserManagementService/src/UserManagementService/Services/IAuditLogService.cs
@@ -1,0 +1,10 @@
+using UserManagementService.Models;
+using UserManagementService.Models.DTOs;
+
+namespace UserManagementService.Services;
+
+public interface IAuditLogService
+{
+  Task LogActionAsync(AuditAction action, Guid actorUserId, Guid targetUserId, string? details = null);
+  Task<List<AuditLogResponse>> GetAuditLogsAsync();
+}

--- a/UserManagementService/src/UserManagementService/Services/IUserProfileService.cs
+++ b/UserManagementService/src/UserManagementService/Services/IUserProfileService.cs
@@ -10,7 +10,7 @@ public interface IUserProfileService
   Task<ServiceResult> GetUserRoleAsync(Guid userId);
   Task<ServiceResult> GetTeamAsync();
   Task<ServiceResult> GetAllUsersAsync();
-  Task<ServiceResult> UpdateUserRoleAsync(Guid userId, UserRole role);
-  Task<ServiceResult> SetUserActiveAsync(Guid userId, bool isActive);
-  Task<ServiceResult> ResendInviteAsync(Guid userId);
+  Task<ServiceResult> UpdateUserRoleAsync(Guid userId, UserRole role, Guid actorUserId);
+  Task<ServiceResult> SetUserActiveAsync(Guid userId, bool isActive, Guid actorUserId);
+  Task<ServiceResult> ResendInviteAsync(Guid userId, Guid actorUserId);
 }

--- a/UserManagementService/src/UserManagementService/Services/UserProfileService.cs
+++ b/UserManagementService/src/UserManagementService/Services/UserProfileService.cs
@@ -11,11 +11,13 @@ public class UserProfileService : IUserProfileService
 {
   private readonly IUserProfileRepository _repository;
   private readonly IEmailService _emailService;
+  private readonly IAuditLogService _auditLogService;
 
-  public UserProfileService(IUserProfileRepository repository, IEmailService emailService)
+  public UserProfileService(IUserProfileRepository repository, IEmailService emailService, IAuditLogService auditLogService)
   {
     _repository = repository;
     _emailService = emailService;
+    _auditLogService = auditLogService;
   }
 
   public async Task<ServiceResult> CreateUserProfileAsync(CreateUserProfileRequest request)
@@ -94,7 +96,7 @@ public class UserProfileService : IUserProfileService
     return ServiceResult.Success(users);
   }
 
-  public async Task<ServiceResult> UpdateUserRoleAsync(Guid userId, UserRole role)
+  public async Task<ServiceResult> UpdateUserRoleAsync(Guid userId, UserRole role, Guid actorUserId)
   {
     if (role == UserRole.Unassigned)
       return ServiceResult.Failure("Cannot set role to Unassigned. Use Member, SalesRep, Manager, or Admin.");
@@ -103,8 +105,15 @@ public class UserProfileService : IUserProfileService
     if (profile == null)
       return ServiceResult.Failure("User profile not found.", 404);
 
+    var previousRole = profile.Role;
     profile.Role = role;
     await _repository.UpdateAsync(profile);
+
+    await _auditLogService.LogActionAsync(
+      AuditAction.RoleChanged,
+      actorUserId,
+      userId,
+      $"Role changed from {previousRole} to {role}");
 
     return ServiceResult.Success(new AdminUserResponse
     {
@@ -117,7 +126,7 @@ public class UserProfileService : IUserProfileService
     });
   }
 
-  public async Task<ServiceResult> SetUserActiveAsync(Guid userId, bool isActive)
+  public async Task<ServiceResult> SetUserActiveAsync(Guid userId, bool isActive, Guid actorUserId)
   {
     var profile = await _repository.GetByIdAsync(userId);
     if (profile == null)
@@ -126,6 +135,9 @@ public class UserProfileService : IUserProfileService
     profile.IsActive = isActive;
     await _repository.UpdateAsync(profile);
 
+    var action = isActive ? AuditAction.AccountActivated : AuditAction.AccountDeactivated;
+    await _auditLogService.LogActionAsync(action, actorUserId, userId);
+
     return ServiceResult.Success(new AdminUserResponse
     {
       UserId = profile.UserId,
@@ -137,7 +149,7 @@ public class UserProfileService : IUserProfileService
     });
   }
 
-  public async Task<ServiceResult> ResendInviteAsync(Guid userId)
+  public async Task<ServiceResult> ResendInviteAsync(Guid userId, Guid actorUserId)
   {
     var profile = await _repository.GetByIdAsync(userId);
     if (profile == null)
@@ -152,6 +164,7 @@ public class UserProfileService : IUserProfileService
     await _repository.UpdateAsync(profile);
 
     await _emailService.SendInviteEmailAsync(profile.Email, newToken);
+    await _auditLogService.LogActionAsync(AuditAction.InviteSent, actorUserId, userId);
 
     return ServiceResult.Success(new ResendInviteResponse
     {


### PR DESCRIPTION
Implements a full audit trail for admin identity actions in UserManagementService, as described in issue #39.

**New endpoint:** `GET /api/users/audit` (Admin only)

**Logged events:** RoleChanged, AccountDeactivated, AccountActivated, InviteSent

Each entry records: actor UserId, target UserId, action, timestamp, and optional details.

Closes #39

Generated with [Claude Code](https://claude.ai/code)