### PR TITLE
feat: add ContactCreatedConsumer to populate Lead funnel bucket

### DIFF
--- a/ReportingService/src/ReportingService.Tests/Consumers/ContactCreatedConsumerTests.cs
+++ b/ReportingService/src/ReportingService.Tests/Consumers/ContactCreatedConsumerTests.cs
@@ -1,0 +1,79 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using ReportingService.Consumers;
+using ReportingService.Data;
+using ReportingService.Models;
+using SharedLibrary.Contacts.Events;
+
+namespace ReportingService.Tests.Consumers;
+
+public class ContactCreatedConsumerTests
+{
+    private ReportingDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<ReportingDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new ReportingDbContext(options);
+    }
+
+    [Fact]
+    public async Task HandleAsync_IncrementsLeadCount_WhenLeadAlreadySeeded()
+    {
+        using var db = CreateDb();
+        db.ContactFunnelProjections.Add(new ContactFunnelProjection { Status = "Lead", Count = 2 });
+        await db.SaveChangesAsync();
+
+        var consumer = new ContactCreatedConsumer(db);
+        await consumer.HandleAsync(new ContactCreated
+        {
+            ContactId = Guid.NewGuid(),
+            FirstName = "Jane",
+            LastName = "Doe",
+            Email = "jane@example.com"
+        });
+
+        var lead = await db.ContactFunnelProjections.FindAsync("Lead");
+        lead!.Count.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task HandleAsync_CreatesLeadProjection_WhenNotSeeded()
+    {
+        using var db = CreateDb();
+
+        var consumer = new ContactCreatedConsumer(db);
+        await consumer.HandleAsync(new ContactCreated
+        {
+            ContactId = Guid.NewGuid(),
+            FirstName = "John",
+            LastName = "Smith",
+            Email = "john@example.com"
+        });
+
+        var lead = await db.ContactFunnelProjections.FindAsync("Lead");
+        lead.Should().NotBeNull();
+        lead!.Count.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task HandleAsync_DoesNotAffectOtherStatuses()
+    {
+        using var db = CreateDb();
+        db.ContactFunnelProjections.Add(new ContactFunnelProjection { Status = "Lead", Count = 1 });
+        db.ContactFunnelProjections.Add(new ContactFunnelProjection { Status = "Prospect", Count = 5 });
+        await db.SaveChangesAsync();
+
+        var consumer = new ContactCreatedConsumer(db);
+        await consumer.HandleAsync(new ContactCreated
+        {
+            ContactId = Guid.NewGuid(),
+            FirstName = "Alice",
+            LastName = "Jones",
+            Email = "alice@example.com"
+        });
+
+        var prospect = await db.ContactFunnelProjections.FindAsync("Prospect");
+        prospect!.Count.Should().Be(5);
+    }
+}

--- a/ReportingService/src/ReportingService/Consumers/ContactCreatedConsumer.cs
+++ b/ReportingService/src/ReportingService/Consumers/ContactCreatedConsumer.cs
@@ -1,0 +1,32 @@
+using MassTransit;
+using ReportingService.Data;
+using ReportingService.Models;
+using SharedLibrary.Contacts.Events;
+
+namespace ReportingService.Consumers;
+
+public class ContactCreatedConsumer : IConsumer<ContactCreated>
+{
+    private readonly ReportingDbContext _db;
+
+    public ContactCreatedConsumer(ReportingDbContext db) => _db = db;
+
+    public async Task Consume(ConsumeContext<ContactCreated> context) =>
+        await HandleAsync(context.Message);
+
+    public async Task HandleAsync(ContactCreated e)
+    {
+        const string leadStatus = "Lead";
+
+        var proj = await _db.ContactFunnelProjections.FindAsync(leadStatus);
+        if (proj == null)
+        {
+            proj = new ContactFunnelProjection { Status = leadStatus };
+            _db.ContactFunnelProjections.Add(proj);
+        }
+        proj.Count++;
+        proj.UpdatedAt = DateTime.UtcNow;
+
+        await _db.SaveChangesAsync();
+    }
+}

--- a/ReportingService/src/ReportingService/Program.cs
+++ b/ReportingService/src/ReportingService/Program.cs
@@ -37,6 +37,7 @@ builder.Services.AddMassTransit(x =>
     x.AddConsumer<DealStageChangedConsumer>();
     x.AddConsumer<DealClosedConsumer>();
     x.AddConsumer<ActivityLoggedConsumer>();
+    x.AddConsumer<ContactCreatedConsumer>();
     x.AddConsumer<ContactStatusChangedConsumer>();
 
     x.UsingRabbitMq((ctx, cfg) =>


### PR DESCRIPTION
Fixes #80

New contacts always start as Lead but ContactCreated was never consumed, leaving the funnel empty. This adds ContactCreatedConsumer which increments the Lead projection row on every ContactCreated event, and registers it in Program.cs alongside the existing consumers. Three unit tests cover seeded/unseeded Lead rows and isolation of other status rows.

Generated with [Claude Code](https://claude.ai/code)