### PR TITLE
fix(tests): set ControllerContext in UMS controller unit tests

### DIFF
--- a/UserManagementService/src/UserManagementService.Tests/Controllers/AdminControllerTests.cs
+++ b/UserManagementService/src/UserManagementService.Tests/Controllers/AdminControllerTests.cs
@@ -1,4 +1,6 @@
+using System.Security.Claims;
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -18,6 +20,16 @@ public class AdminControllerTests
   public AdminControllerTests()
   {
     _sut = new AdminController(_serviceMock.Object, _loggerMock.Object);
+    _sut.ControllerContext = new ControllerContext
+    {
+      HttpContext = new DefaultHttpContext
+      {
+        User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+        {
+          new Claim("UserId", Guid.NewGuid().ToString()),
+        })),
+      },
+    };
   }
 
   // ── GetAllUsers ───────────────────────────────────────────────────────────

--- a/UserManagementService/src/UserManagementService.Tests/Controllers/UsersControllerTests.cs
+++ b/UserManagementService/src/UserManagementService.Tests/Controllers/UsersControllerTests.cs
@@ -1,4 +1,6 @@
+using System.Security.Claims;
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -20,6 +22,16 @@ public class UsersControllerTests
   public UsersControllerTests()
   {
     _sut = new UsersController(_serviceMock.Object, _auditLogServiceMock.Object, _loggerMock.Object);
+    _sut.ControllerContext = new ControllerContext
+    {
+      HttpContext = new DefaultHttpContext
+      {
+        User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+        {
+          new Claim("UserId", Guid.NewGuid().ToString()),
+        })),
+      },
+    };
   }
 
   // ── CreateUserProfile ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `AdminControllerTests` and `UsersControllerTests` were not setting up `ControllerContext`, leaving `HttpContext` null
- PR #95 (audit log) added `GetActorUserId()` to both controllers, which calls `User.FindFirstValue()` — this accesses `HttpContext.User` and throws `NullReferenceException` when `HttpContext` is null
- Every action that passes the actor ID was returning 500 instead of the expected status code, causing 14 unit test failures

## Fix

Added `ControllerContext` initialization in both test constructors with a `DefaultHttpContext` carrying a `ClaimsPrincipal` with a `UserId` claim.

## Why a standalone PR

The fix was originally committed to the `claude/issue-39` branch after PR #95 was already merged, so it never landed on `main`. Any branch cut after that merge inherits the broken tests. This PR closes the gap so new branches don't carry the same breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)