### PR TITLE
feat(frontend): add v2.1 UI — invite flow, forgot/reset password, password policy

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,9 @@ import AdminRoute from './components/AdminRoute.jsx'
 import Layout from './components/Layout.jsx'
 import Login from './pages/auth/Login.jsx'
 import Register from './pages/auth/Register.jsx'
+import ForgotPassword from './pages/auth/ForgotPassword.jsx'
+import ResetPassword from './pages/auth/ResetPassword.jsx'
+import AcceptInvite from './pages/auth/AcceptInvite.jsx'
 import ChangePassword from './pages/auth/ChangePassword.jsx'
 import Profile from './pages/profile/Profile.jsx'
 import ContactList from './pages/contacts/ContactList.jsx'
@@ -26,7 +29,9 @@ export default function App() {
       <BrowserRouter>
         <Routes>
           <Route path="/login" element={<Login />} />
-          <Route path="/register" element={<Register />} />
+          <Route path="/forgot-password" element={<ForgotPassword />} />
+          <Route path="/reset-password" element={<ResetPassword />} />
+          <Route path="/accept-invite" element={<AcceptInvite />} />
           <Route element={<ProtectedRoute />}>
             <Route path="/change-password" element={<ChangePassword />} />
           </Route>
@@ -50,6 +55,7 @@ export default function App() {
               <Route path="/profile" element={<Profile />} />
               <Route element={<AdminRoute />}>
                 <Route path="/admin/users" element={<AdminUserList />} />
+                <Route path="/register" element={<Register />} />
               </Route>
             </Route>
           </Route>

--- a/frontend/src/api/auth.api.js
+++ b/frontend/src/api/auth.api.js
@@ -19,4 +19,19 @@ export const authApi = {
       method: 'POST',
       body: JSON.stringify({ newPassword }),
     }),
+  forgotPassword: (email) =>
+    apiFetch(`${BASE}/auth/forgot-password`, {
+      method: 'POST',
+      body: JSON.stringify({ email }),
+    }),
+  resetPassword: (token, newPassword) =>
+    apiFetch(`${BASE}/auth/reset-password`, {
+      method: 'POST',
+      body: JSON.stringify({ token, newPassword }),
+    }),
+  acceptInvite: (token, password) =>
+    apiFetch(`${BASE}/registration/accept-invite`, {
+      method: 'POST',
+      body: JSON.stringify({ token, password }),
+    }),
 }

--- a/frontend/src/api/users.api.js
+++ b/frontend/src/api/users.api.js
@@ -20,4 +20,13 @@ export const adminApi = {
       method: 'PUT',
       body: JSON.stringify({ isActive }),
     }),
+  inviteUser: (email) =>
+    apiFetch('/auth/api/users/invite', {
+      method: 'POST',
+      body: JSON.stringify({ email }),
+    }),
+  resendInvite: (userId) =>
+    apiFetch(`${BASE}/${userId}/resend-invite`, {
+      method: 'POST',
+    }),
 }

--- a/frontend/src/pages/admin/AdminUserList.jsx
+++ b/frontend/src/pages/admin/AdminUserList.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { ShieldCheck, UserCheck, UserX } from 'lucide-react'
+import { Mail, RefreshCw, ShieldCheck, UserCheck, UserPlus, UserX } from 'lucide-react'
 import { adminApi } from '../../api/users.api.js'
 import { useAuth } from '../../context/AuthContext.jsx'
 import { toast } from '../../hooks/use-toast.js'
@@ -24,6 +24,8 @@ import {
   DialogDescription,
   DialogFooter,
 } from '../../components/ui/dialog.jsx'
+import { Input } from '../../components/ui/input.jsx'
+import { Label } from '../../components/ui/label.jsx'
 import { EmptyState } from '../../components/EmptyState.jsx'
 
 const ROLES = ['Unassigned', 'Member', 'SalesRep', 'Manager', 'Admin']
@@ -40,6 +42,8 @@ export default function AdminUserList() {
   const { user: currentUser } = useAuth()
   const queryClient = useQueryClient()
   const [confirmAction, setConfirmAction] = useState(null)
+  const [inviteOpen, setInviteOpen] = useState(false)
+  const [inviteEmail, setInviteEmail] = useState('')
 
   const { data: users = [], isLoading, error } = useQuery({
     queryKey: ['admin', 'users'],
@@ -68,6 +72,24 @@ export default function AdminUserList() {
     },
   })
 
+  const inviteMutation = useMutation({
+    mutationFn: (email) => adminApi.inviteUser(email),
+    onSuccess: () => {
+      toast({ variant: 'success', title: 'Invite sent', description: `An invite email was sent to ${inviteEmail}.` })
+      setInviteOpen(false)
+      setInviteEmail('')
+    },
+    onError: (err) => toast({ variant: 'destructive', title: 'Invite failed', description: err.message }),
+  })
+
+  const resendInviteMutation = useMutation({
+    mutationFn: (userId) => adminApi.resendInvite(userId),
+    onSuccess: (_, userId) => {
+      toast({ variant: 'success', title: 'Invite resent' })
+    },
+    onError: (err) => toast({ variant: 'destructive', title: 'Resend failed', description: err.message }),
+  })
+
   function handleRoleChange(userId, role) {
     roleMutation.mutate({ userId, role })
   }
@@ -84,11 +106,22 @@ export default function AdminUserList() {
     activeMutation.mutate({ userId: confirmAction.user.userId, isActive: false })
   }
 
+  function handleInviteSubmit(e) {
+    e.preventDefault()
+    inviteMutation.mutate(inviteEmail)
+  }
+
   return (
     <div>
-      <div className="flex items-center gap-3 mb-5">
-        <ShieldCheck size={24} className="text-blue-600" />
-        <h1 className="text-2xl font-bold text-gray-900">User Management</h1>
+      <div className="flex items-center justify-between mb-5">
+        <div className="flex items-center gap-3">
+          <ShieldCheck size={24} className="text-blue-600" />
+          <h1 className="text-2xl font-bold text-gray-900">User Management</h1>
+        </div>
+        <Button size="sm" onClick={() => setInviteOpen(true)}>
+          <UserPlus size={14} className="mr-1.5" />
+          Invite user
+        </Button>
       </div>
 
       {isLoading ? (
@@ -130,12 +163,13 @@ export default function AdminUserList() {
                 <TableHead>Role</TableHead>
                 <TableHead>Status</TableHead>
                 <TableHead>Joined</TableHead>
-                <TableHead className="w-32" />
+                <TableHead className="w-48" />
               </TableRow>
             </TableHeader>
             <TableBody>
               {users.map((u) => {
                 const isSelf = u.userId === currentUser?.userId
+                const isPendingInvite = !!u.invitePendingAt
                 return (
                   <TableRow key={u.userId} className={!u.isActive ? 'opacity-50' : ''}>
                     <TableCell className="font-medium">
@@ -162,14 +196,33 @@ export default function AdminUserList() {
                       </Select>
                     </TableCell>
                     <TableCell>
-                      <Badge variant={u.isActive ? 'customer' : 'churned'}>
-                        {u.isActive ? 'Active' : 'Inactive'}
-                      </Badge>
+                      {isPendingInvite ? (
+                        <Badge variant="outline" className="text-amber-600 border-amber-300 bg-amber-50">
+                          <Mail size={10} className="mr-1" />
+                          Invite pending
+                        </Badge>
+                      ) : (
+                        <Badge variant={u.isActive ? 'customer' : 'churned'}>
+                          {u.isActive ? 'Active' : 'Inactive'}
+                        </Badge>
+                      )}
                     </TableCell>
                     <TableCell>{new Date(u.createdAt).toLocaleDateString()}</TableCell>
                     <TableCell>
                       <div className="flex gap-1 justify-end">
-                        {u.isActive ? (
+                        {isPendingInvite ? (
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            className="h-7 text-xs text-blue-600 hover:text-blue-700 hover:bg-blue-50"
+                            onClick={() => resendInviteMutation.mutate(u.userId)}
+                            disabled={resendInviteMutation.isPending}
+                            title="Resend invite email"
+                          >
+                            <RefreshCw size={14} className="mr-1" />
+                            Resend invite
+                          </Button>
+                        ) : u.isActive ? (
                           <Button
                             size="sm"
                             variant="ghost"
@@ -204,6 +257,48 @@ export default function AdminUserList() {
         </Card>
       )}
 
+      {/* Invite user dialog */}
+      <Dialog open={inviteOpen} onOpenChange={(open) => { if (!open) { setInviteOpen(false); setInviteEmail('') } }}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Invite user</DialogTitle>
+            <DialogDescription>
+              Send an invite email to a new user. They'll receive a link to set their password.
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleInviteSubmit}>
+            <div className="flex flex-col gap-3 py-2">
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="inviteEmail">Email address</Label>
+                <Input
+                  id="inviteEmail"
+                  type="email"
+                  value={inviteEmail}
+                  onChange={(e) => setInviteEmail(e.target.value)}
+                  required
+                  autoComplete="off"
+                  placeholder="user@example.com"
+                />
+              </div>
+            </div>
+            <DialogFooter className="mt-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => { setInviteOpen(false); setInviteEmail('') }}
+                disabled={inviteMutation.isPending}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={inviteMutation.isPending}>
+                {inviteMutation.isPending ? 'Sending…' : 'Send invite'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Deactivate confirmation dialog */}
       <Dialog open={!!confirmAction} onOpenChange={(open) => { if (!open) setConfirmAction(null) }}>
         <DialogContent className="sm:max-w-sm">
           <DialogHeader>

--- a/frontend/src/pages/auth/AcceptInvite.jsx
+++ b/frontend/src/pages/auth/AcceptInvite.jsx
@@ -1,34 +1,48 @@
 import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { authApi } from '../../api/auth.api.js'
-import { useAuth } from '../../context/AuthContext.jsx'
 import { Button } from '../../components/ui/button.jsx'
 import { Input } from '../../components/ui/input.jsx'
 import { Label } from '../../components/ui/label.jsx'
 import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card.jsx'
 
-export default function ChangePassword() {
-  const { login } = useAuth()
+export default function AcceptInvite() {
   const navigate = useNavigate()
-  const [newPassword, setNewPassword] = useState('')
+  const [searchParams] = useSearchParams()
+  const token = searchParams.get('token') ?? ''
+
+  const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
   const [error, setError] = useState(null)
   const [loading, setLoading] = useState(false)
+
+  if (!token) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+        <Card className="w-full max-w-sm shadow-md">
+          <CardContent className="pt-6">
+            <p className="text-sm text-red-600">
+              Invalid or missing invite token. Please contact your administrator for a new invite link.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
 
   async function handleSubmit(e) {
     e.preventDefault()
     setError(null)
 
-    if (newPassword !== confirmPassword) {
+    if (password !== confirmPassword) {
       setError('Passwords do not match.')
       return
     }
 
     setLoading(true)
     try {
-      const data = await authApi.changePassword(newPassword)
-      login(data.token)
-      navigate('/contacts', { replace: true })
+      await authApi.acceptInvite(token, password)
+      navigate('/login', { replace: true, state: { message: 'Account created successfully. You can now sign in.' } })
     } catch (err) {
       setError(err.message)
     } finally {
@@ -40,9 +54,9 @@ export default function ChangePassword() {
     <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
       <Card className="w-full max-w-sm shadow-md">
         <CardHeader>
-          <CardTitle className="text-xl">Set your password</CardTitle>
+          <CardTitle className="text-xl">Accept invitation</CardTitle>
           <p className="text-sm text-gray-500 mt-1">
-            You must set a new password before continuing.
+            Set a password to activate your account.
           </p>
         </CardHeader>
         <CardContent>
@@ -53,19 +67,16 @@ export default function ChangePassword() {
               </p>
             )}
             <div className="flex flex-col gap-1.5">
-              <Label htmlFor="newPassword">New password</Label>
+              <Label htmlFor="password">Password</Label>
               <Input
-                id="newPassword"
+                id="password"
                 type="password"
-                value={newPassword}
-                onChange={(e) => setNewPassword(e.target.value)}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
                 required
                 minLength={8}
                 autoComplete="new-password"
               />
-              <p className="text-xs text-gray-500">
-                Must be at least 8 characters with uppercase, lowercase, digit, and special character.
-              </p>
             </div>
             <div className="flex flex-col gap-1.5">
               <Label htmlFor="confirmPassword">Confirm password</Label>
@@ -79,9 +90,18 @@ export default function ChangePassword() {
                 autoComplete="new-password"
               />
             </div>
+            <p className="text-xs text-gray-500">
+              Must be at least 8 characters with uppercase, lowercase, digit, and special character.
+            </p>
             <Button type="submit" disabled={loading} className="w-full">
-              {loading ? 'Saving…' : 'Set password'}
+              {loading ? 'Activating…' : 'Activate account'}
             </Button>
+            <p className="text-sm text-gray-500 text-center">
+              Already have an account?{' '}
+              <Link to="/login" className="text-blue-600 hover:underline">
+                Sign in
+              </Link>
+            </p>
           </form>
         </CardContent>
       </Card>

--- a/frontend/src/pages/auth/ForgotPassword.jsx
+++ b/frontend/src/pages/auth/ForgotPassword.jsx
@@ -1,0 +1,75 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { authApi } from '../../api/auth.api.js'
+import { Button } from '../../components/ui/button.jsx'
+import { Input } from '../../components/ui/input.jsx'
+import { Label } from '../../components/ui/label.jsx'
+import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card.jsx'
+
+export default function ForgotPassword() {
+  const [email, setEmail] = useState('')
+  const [error, setError] = useState(null)
+  const [success, setSuccess] = useState(null)
+  const [loading, setLoading] = useState(false)
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    setError(null)
+    setSuccess(null)
+    setLoading(true)
+    try {
+      const data = await authApi.forgotPassword(email)
+      setSuccess(data?.message ?? 'If that email is registered, a reset link has been sent.')
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <Card className="w-full max-w-sm shadow-md">
+        <CardHeader>
+          <CardTitle className="text-xl">Reset your password</CardTitle>
+          <p className="text-sm text-gray-500 mt-1">
+            Enter your email and we'll send you a reset link.
+          </p>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+            {error && (
+              <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-md border border-red-200">
+                {error}
+              </p>
+            )}
+            {success && (
+              <p className="text-sm text-emerald-700 bg-emerald-50 px-3 py-2 rounded-md border border-emerald-200">
+                {success}
+              </p>
+            )}
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                autoComplete="email"
+              />
+            </div>
+            <Button type="submit" disabled={loading || !!success} className="w-full">
+              {loading ? 'Sending…' : 'Send reset link'}
+            </Button>
+            <p className="text-sm text-gray-500 text-center">
+              <Link to="/login" className="text-blue-600 hover:underline">
+                Back to sign in
+              </Link>
+            </p>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/pages/auth/Login.jsx
+++ b/frontend/src/pages/auth/Login.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useNavigate, useLocation } from 'react-router-dom'
 import { authApi } from '../../api/auth.api.js'
 import { useAuth } from '../../context/AuthContext.jsx'
 import { Button } from '../../components/ui/button.jsx'
@@ -10,10 +10,12 @@ import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/ca
 export default function Login() {
   const { login } = useAuth()
   const navigate = useNavigate()
+  const location = useLocation()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState(null)
   const [loading, setLoading] = useState(false)
+  const successMessage = location.state?.message ?? null
 
   async function handleSubmit(e) {
     e.preventDefault()
@@ -43,6 +45,11 @@ export default function Login() {
                 {error}
               </p>
             )}
+            {successMessage && (
+              <p className="text-sm text-emerald-700 bg-emerald-50 px-3 py-2 rounded-md border border-emerald-200">
+                {successMessage}
+              </p>
+            )}
             <div className="flex flex-col gap-1.5">
               <Label htmlFor="email">Email</Label>
               <Input
@@ -55,7 +62,12 @@ export default function Login() {
               />
             </div>
             <div className="flex flex-col gap-1.5">
-              <Label htmlFor="password">Password</Label>
+              <div className="flex items-center justify-between">
+                <Label htmlFor="password">Password</Label>
+                <Link to="/forgot-password" className="text-xs text-blue-600 hover:underline">
+                  Forgot password?
+                </Link>
+              </div>
               <Input
                 id="password"
                 type="password"
@@ -68,12 +80,6 @@ export default function Login() {
             <Button type="submit" disabled={loading} className="w-full">
               {loading ? 'Signing in…' : 'Sign in'}
             </Button>
-            <p className="text-sm text-gray-500 text-center">
-              No account?{' '}
-              <Link to="/register" className="text-blue-600 hover:underline">
-                Register
-              </Link>
-            </p>
           </form>
         </CardContent>
       </Card>

--- a/frontend/src/pages/auth/Register.jsx
+++ b/frontend/src/pages/auth/Register.jsx
@@ -67,9 +67,12 @@ export default function Register() {
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 required
-                minLength={6}
+                minLength={8}
                 autoComplete="new-password"
               />
+              <p className="text-xs text-gray-500">
+                Must be at least 8 characters with uppercase, lowercase, digit, and special character.
+              </p>
             </div>
             <Button type="submit" disabled={loading} className="w-full">
               {loading ? 'Creating account…' : 'Create account'}

--- a/frontend/src/pages/auth/ResetPassword.jsx
+++ b/frontend/src/pages/auth/ResetPassword.jsx
@@ -1,19 +1,38 @@
 import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { authApi } from '../../api/auth.api.js'
-import { useAuth } from '../../context/AuthContext.jsx'
 import { Button } from '../../components/ui/button.jsx'
 import { Input } from '../../components/ui/input.jsx'
 import { Label } from '../../components/ui/label.jsx'
 import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card.jsx'
 
-export default function ChangePassword() {
-  const { login } = useAuth()
+export default function ResetPassword() {
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const token = searchParams.get('token') ?? ''
+
   const [newPassword, setNewPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
   const [error, setError] = useState(null)
   const [loading, setLoading] = useState(false)
+
+  if (!token) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+        <Card className="w-full max-w-sm shadow-md">
+          <CardContent className="pt-6">
+            <p className="text-sm text-red-600">
+              Invalid or missing reset token. Please request a new{' '}
+              <Link to="/forgot-password" className="text-blue-600 hover:underline">
+                password reset link
+              </Link>
+              .
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
 
   async function handleSubmit(e) {
     e.preventDefault()
@@ -26,9 +45,8 @@ export default function ChangePassword() {
 
     setLoading(true)
     try {
-      const data = await authApi.changePassword(newPassword)
-      login(data.token)
-      navigate('/contacts', { replace: true })
+      await authApi.resetPassword(token, newPassword)
+      navigate('/login', { replace: true, state: { message: 'Password reset successfully. You can now sign in.' } })
     } catch (err) {
       setError(err.message)
     } finally {
@@ -40,10 +58,7 @@ export default function ChangePassword() {
     <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
       <Card className="w-full max-w-sm shadow-md">
         <CardHeader>
-          <CardTitle className="text-xl">Set your password</CardTitle>
-          <p className="text-sm text-gray-500 mt-1">
-            You must set a new password before continuing.
-          </p>
+          <CardTitle className="text-xl">Set new password</CardTitle>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleSubmit} className="flex flex-col gap-4">
@@ -63,9 +78,6 @@ export default function ChangePassword() {
                 minLength={8}
                 autoComplete="new-password"
               />
-              <p className="text-xs text-gray-500">
-                Must be at least 8 characters with uppercase, lowercase, digit, and special character.
-              </p>
             </div>
             <div className="flex flex-col gap-1.5">
               <Label htmlFor="confirmPassword">Confirm password</Label>
@@ -79,8 +91,11 @@ export default function ChangePassword() {
                 autoComplete="new-password"
               />
             </div>
+            <p className="text-xs text-gray-500">
+              Must be at least 8 characters with uppercase, lowercase, digit, and special character.
+            </p>
             <Button type="submit" disabled={loading} className="w-full">
-              {loading ? 'Saving…' : 'Set password'}
+              {loading ? 'Saving…' : 'Set new password'}
             </Button>
           </form>
         </CardContent>


### PR DESCRIPTION
Implements all missing and broken frontend pieces from issue #94:

- New pages: ForgotPassword, ResetPassword, AcceptInvite
- API methods: forgotPassword, resetPassword, acceptInvite, inviteUser, resendInvite
- AdminUserList: invite dialog, resend invite button, pending-invite badge
- Login: Forgot password link, success message display
- Register: moved to Admin-only route
- Password policy: minLength 6→8 + complexity hint in Register and ChangePassword

Closes #94

Generated with [Claude Code](https://claude.ai/code)